### PR TITLE
Disable CSS optimization to fix missing critters module in Next.js build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,7 @@ const nextConfig = {
   // Experimental features for optimization
   experimental: {
     webVitalsAttribution: ['CLS', 'LCP'],
+    optimizeCss: false,
   },
   
   // Allowed dev origins to fix cross-origin warnings


### PR DESCRIPTION
## Summary
- disable Next.js `optimizeCss` experiment so build no longer requires `critters`

## Testing
- `npm test` *(fails: npm not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c384a35218832b841316cdc3f84862