### PR TITLE
Skip lighthouse step in CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "health-check": "node scripts/health-check.js",
     "health-monitor": "node scripts/health-check.js continuous",
     "build:analyze": "ANALYZE=true npm run build",
-    "postbuild": "npm run lighthouse",
+    "postbuild": "node scripts/postbuild.js",
     "db:push": "drizzle-kit push",
     "db:push:force": "drizzle-kit push --force",
     "db:studio": "drizzle-kit studio",

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,10 @@
+const { spawnSync } = require('child_process');
+
+if (!process.env.CI) {
+  const result = spawnSync('npm', ['run', 'lighthouse'], { stdio: 'inherit', shell: true });
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+} else {
+  console.log('Skipping lighthouse in CI environment');
+}


### PR DESCRIPTION
## Summary
- run Lighthouse only when CI is not set
- add postbuild script to check CI env

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint`
- `CI=1 npm run build` *(fails: DATABASE_URL environment variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68c3975aed44832b9284a4111c1869b2