### PR TITLE
Fix navigation routing and remove menu icons

### DIFF
--- a/src/app/announcements/page.tsx
+++ b/src/app/announcements/page.tsx
@@ -1,0 +1,11 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
+export default function AnnouncementsPage() {
+  return (
+    <MainLayout className="p-8">
+      <h1 className="text-3xl font-bold">Announcements</h1>
+      <p className="mt-4">Stay updated with the latest community news.</p>
+    </MainLayout>
+  )
+}
+

--- a/src/app/classifieds/page.tsx
+++ b/src/app/classifieds/page.tsx
@@ -1,0 +1,11 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
+export default function ClassifiedsPage() {
+  return (
+    <MainLayout className="p-8">
+      <h1 className="text-3xl font-bold">Classifieds</h1>
+      <p className="mt-4">Buy, sell and trade within the community.</p>
+    </MainLayout>
+  )
+}
+

--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -1,0 +1,11 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
+export default function DirectoryPage() {
+  return (
+    <MainLayout className="p-8">
+      <h1 className="text-3xl font-bold">Directory</h1>
+      <p className="mt-4">Browse community businesses and organizations.</p>
+    </MainLayout>
+  )
+}
+

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,11 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
+export default function EventsPage() {
+  return (
+    <MainLayout className="p-8">
+      <h1 className="text-3xl font-bold">Events</h1>
+      <p className="mt-4">Find upcoming community events and gatherings.</p>
+    </MainLayout>
+  )
+}
+

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -1,0 +1,11 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
+export default function GroupsPage() {
+  return (
+    <MainLayout className="p-8">
+      <h1 className="text-3xl font-bold">Groups</h1>
+      <p className="mt-4">Connect with fellow members through interest groups.</p>
+    </MainLayout>
+  )
+}
+

--- a/src/app/opportunities/page.tsx
+++ b/src/app/opportunities/page.tsx
@@ -1,0 +1,11 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
+export default function OpportunitiesPage() {
+  return (
+    <MainLayout className="p-8">
+      <h1 className="text-3xl font-bold">Opportunities</h1>
+      <p className="mt-4">Explore scholarships, jobs and other opportunities.</p>
+    </MainLayout>
+  )
+}
+

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,0 +1,11 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
+export default function ServicesPage() {
+  return (
+    <MainLayout className="p-8">
+      <h1 className="text-3xl font-bold">Services</h1>
+      <p className="mt-4">Discover service providers within the community.</p>
+    </MainLayout>
+  )
+}
+

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -30,8 +30,6 @@ export function Header() {
                 className="text-neutral-600 hover:text-primary-600 px-3 py-2 text-sm font-medium transition-colors duration-200 rounded-lg hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
                 aria-label={`Go to ${item.label}`}
               >
-                <span className="sr-only">{item.icon}</span>
-                <span aria-hidden="true" className="mr-2">{item.icon}</span>
                 {item.label}
               </Link>
             ))}
@@ -92,7 +90,6 @@ export function Header() {
                 className="text-neutral-600 hover:text-primary-600 block px-3 py-2 text-base font-medium rounded-lg hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
                 aria-label={`Go to ${item.label}`}
               >
-                <span aria-hidden="true" className="mr-3">{item.icon}</span>
                 {item.label}
               </Link>
             ))}

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -272,13 +272,13 @@ export const SITE_MAP: SiteMapItem[] = [
 
 // Navigation structure for main menu
 export const MAIN_NAVIGATION = [
-  { label: 'Directory', path: '/directory', icon: '🏢' },
-  { label: 'Services', path: '/services', icon: '⚡' },
-  { label: 'Events', path: '/events', icon: '📅' },
-  { label: 'Announcements', path: '/announcements', icon: '📢' },
-  { label: 'Opportunities', path: '/opportunities', icon: '🎯' },
-  { label: 'Classifieds', path: '/classifieds', icon: '🏷️' },
-  { label: 'Groups', path: '/groups', icon: '💬' }
+  { label: 'Directory', path: '/directory' },
+  { label: 'Services', path: '/services' },
+  { label: 'Events', path: '/events' },
+  { label: 'Announcements', path: '/announcements' },
+  { label: 'Opportunities', path: '/opportunities' },
+  { label: 'Classifieds', path: '/classifieds' },
+  { label: 'Groups', path: '/groups' }
 ]
 
 // Footer navigation


### PR DESCRIPTION
## Summary
- remove emoji icons from top navigation links
- add placeholder pages for Directory, Services, Events, Announcements, Opportunities, Classifieds, and Groups
- update sitemap navigation data accordingly

## Testing
- `npm test` (no tests found)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3a8951054832b80734d057a32d1ab