### PR TITLE
Add analytics embed configuration page to prevent 404 errors

### DIFF
--- a/src/app/configuration/analytics-embed/page.tsx
+++ b/src/app/configuration/analytics-embed/page.tsx
@@ -1,0 +1,12 @@
+import { MainLayout } from '@/components/layout/MainLayout'
+
+export default function AnalyticsEmbedPage() {
+  return (
+    <MainLayout className="p-8">
+      <h1 className="text-3xl font-bold">Analytics Embed</h1>
+      <p className="mt-4">
+        Configure and manage analytics embedding for your dashboard.
+      </p>
+    </MainLayout>
+  )
+}


### PR DESCRIPTION
## Summary
- add analytics embed configuration page to eliminate 404 when following configuration links

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c3bd4af650832ba625916513334e5f