### PR TITLE
Ensure Prisma seeding works out of the box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ jspm_packages/
 .env.test.local
 .env.production.local
 .env.local
+!prisma/.env
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/prisma/.env
+++ b/prisma/.env
@@ -1,0 +1,2 @@
+DATABASE_URL="file:./dev.db"
+SQLITE_DATABASE_URL="file:./dev.db"

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,16 @@
+import 'dotenv/config'
 import { PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
+
+// Ensure Prisma always receives a usable DATABASE_URL.
+// In local environments we prefer SQLite while production can supply its own connection string.
+if (!process.env.DATABASE_URL) {
+  if (process.env.SQLITE_DATABASE_URL) {
+    process.env.DATABASE_URL = process.env.SQLITE_DATABASE_URL
+  } else {
+    process.env.DATABASE_URL = 'file:./prisma/dev.db'
+  }
+}
 
 const prisma = new PrismaClient()
 
@@ -204,7 +215,7 @@ async function main() {
     const user = users[Math.floor(Math.random() * users.length)]
     
     try {
-      await prisma.rsvp.create({
+      await prisma.rSVP.create({
         data: {
           eventId: event.id,
           userId: user.id,


### PR DESCRIPTION
## Summary
- load Prisma seed script environment from dotenv and fall back to the bundled SQLite database URL when none is provided
- correct the RSVP seeding call to use the Prisma client accessor and commit a default prisma/.env for local SQLite setups
- expose prisma/.env in git so developers can run db:push and db:seed without extra configuration

## Testing
- npm run db:push
- npm run db:seed
- npm run db:reset

------
https://chatgpt.com/codex/tasks/task_e_68cbd18ea978832ba14300495b9286e7