### PR TITLE
Fix seed fallback SQLite URL

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,7 +8,7 @@ if (!process.env.DATABASE_URL) {
   if (process.env.SQLITE_DATABASE_URL) {
     process.env.DATABASE_URL = process.env.SQLITE_DATABASE_URL
   } else {
-    process.env.DATABASE_URL = 'file:./prisma/dev.db'
+    process.env.DATABASE_URL = 'file:./dev.db'
   }
 }
 


### PR DESCRIPTION
## Summary
- update the seed script to default the SQLite connection string to the dev.db file in the prisma directory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbd8ca5524832b95edd59f87413ecf