### PR TITLE
Populate community pages with curated sample content

### DIFF
--- a/src/app/announcements/page.tsx
+++ b/src/app/announcements/page.tsx
@@ -1,10 +1,111 @@
+import Link from 'next/link'
 import { MainLayout } from '@/components/layout/MainLayout'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
+import { formatDate, formatRelativeTime } from '@/lib/utils'
+import { sampleAnnouncements } from '@/data/sample-content'
+
+const announcementTypeLabels: Record<string, string> = {
+  ACHIEVEMENT: 'Achievement',
+  NOTICE: 'Community notice',
+  BEREAVEMENT: 'Bereavement',
+  WEDDING: 'Wedding',
+  BIRTH: 'New arrival'
+}
 
 export default function AnnouncementsPage() {
   return (
-    <MainLayout className="p-8">
-      <h1 className="text-3xl font-bold">Announcements</h1>
-      <p className="mt-4">Stay updated with the latest community news.</p>
+    <MainLayout className="bg-neutral-50">
+      {/* Hero */}
+      <section className="bg-gradient-to-r from-primary-700 to-secondary-700 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+          <div className="max-w-3xl">
+            <Badge variant="featured" size="sm" className="mb-4 bg-white/10 text-white border-white/20">
+              UiQ Community Newsroom
+            </Badge>
+            <h1 className="text-4xl md:text-5xl font-bold mb-4">Stories that bind us together</h1>
+            <p className="text-lg text-primary-100 mb-6">
+              Share milestones, honour loved ones, and stay informed about the latest updates from Ugandans across Queensland.
+            </p>
+            <div className="flex flex-wrap gap-4 text-sm text-primary-100">
+              <span>{sampleAnnouncements.length} active announcements</span>
+              <span>Updated {formatRelativeTime(sampleAnnouncements[0].publishedAt)}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 space-y-12">
+        <section className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h2 className="text-3xl font-bold text-gray-900">Latest announcements</h2>
+            <p className="text-gray-600 mt-2">
+              Celebrations, condolences, and community updates curated by UiQ moderators.
+            </p>
+          </div>
+          <Button size="lg" variant="outline">
+            Share an announcement
+          </Button>
+        </section>
+
+        <section className="grid gap-6 md:grid-cols-2">
+          {sampleAnnouncements.map((announcement) => (
+            <Card key={announcement.id} hoverable className="flex flex-col justify-between">
+              <CardHeader>
+                <div className="flex flex-wrap items-center gap-3 mb-3">
+                  <Badge variant="outline" className="border-primary-200 text-primary-700">
+                    {announcementTypeLabels[announcement.type] ?? announcement.type.toLowerCase()}
+                  </Badge>
+                  <span className="text-sm text-gray-500">{formatDate(announcement.publishedAt)}</span>
+                </div>
+                <CardTitle className="text-2xl leading-snug">{announcement.title}</CardTitle>
+                <p className="text-sm text-gray-500">Shared by {announcement.author}</p>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-gray-700 leading-relaxed">{announcement.body}</p>
+                <div className="flex items-center justify-between text-sm text-gray-500">
+                  <span>Updated {formatRelativeTime(announcement.publishedAt)}</span>
+                  <Link href={`/announcements/${announcement.id}`} className="inline-flex items-center text-primary-700 font-semibold">
+                    View details
+                    <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+
+        <section className="bg-white border border-gray-200 rounded-2xl p-8">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6 mb-6">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Support & wellbeing resources</h2>
+              <p className="text-gray-600 mt-1">
+                Connect families navigating grief, mental health, or milestone celebrations with trusted UiQ support.
+              </p>
+            </div>
+            <Link href="/community" className="text-primary-700 font-semibold">
+              Community care hub →
+            </Link>
+          </div>
+          <div className="grid md:grid-cols-3 gap-6 text-sm text-gray-700">
+            <div className="p-4 rounded-xl bg-primary-50 border border-primary-100">
+              <p className="font-semibold text-primary-800 mb-2">Bereavement support circles</p>
+              <p>Weekly virtual gatherings offering prayer, counselling, and practical assistance.</p>
+            </div>
+            <div className="p-4 rounded-xl bg-primary-50 border border-primary-100">
+              <p className="font-semibold text-primary-800 mb-2">Celebration planning</p>
+              <p>Guides and vendor referrals for weddings, baby showers, and cultural ceremonies.</p>
+            </div>
+            <div className="p-4 rounded-xl bg-primary-50 border border-primary-100">
+              <p className="font-semibold text-primary-800 mb-2">Emergency assistance fund</p>
+              <p>Apply for short-term financial support coordinated by UiQ welfare leaders.</p>
+            </div>
+          </div>
+        </section>
+      </div>
     </MainLayout>
   )
 }

--- a/src/app/classifieds/page.tsx
+++ b/src/app/classifieds/page.tsx
@@ -1,10 +1,176 @@
+import Image from 'next/image'
+import Link from 'next/link'
 import { MainLayout } from '@/components/layout/MainLayout'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
+import { formatCurrency, formatRelativeTime } from '@/lib/utils'
+import { sampleListings, type SampleListing } from '@/data/sample-content'
+
+const listingTypeLabels: Record<string, { label: string; description: string }> = {
+  housing: {
+    label: 'Housing & accommodation',
+    description: 'Rooms, flat shares, and temporary stays within trusted households.'
+  },
+  sale: {
+    label: 'For sale',
+    description: 'Furniture, cultural items, catering packages, and community resources.'
+  },
+  gig: {
+    label: 'Gigs & services',
+    description: 'Short-term work, event entertainment, and specialist skills.'
+  }
+}
 
 export default function ClassifiedsPage() {
+  const listingsByType = sampleListings.reduce<Record<string, SampleListing[]>>((acc, listing) => {
+    acc[listing.type] = acc[listing.type] ? [...acc[listing.type], listing] : [listing]
+    return acc
+  }, {})
+
   return (
-    <MainLayout className="p-8">
-      <h1 className="text-3xl font-bold">Classifieds</h1>
-      <p className="mt-4">Buy, sell and trade within the community.</p>
+    <MainLayout className="bg-neutral-50">
+      {/* Hero */}
+      <section className="bg-gradient-to-r from-amber-500 via-amber-600 to-amber-700 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+          <div className="grid lg:grid-cols-2 gap-12 items-center">
+            <div>
+              <Badge variant="featured" size="sm" className="mb-4 bg-white/10 text-white border-white/20">
+                UiQ Community Marketplace
+              </Badge>
+              <h1 className="text-4xl md:text-5xl font-bold mb-4">Buy, sell, and support within the community</h1>
+              <p className="text-lg text-amber-100 mb-8">
+                Find housing, discover cultural experiences, and hire trusted professionals who understand Ugandan life in
+                Queensland.
+              </p>
+
+              <div className="flex flex-wrap gap-6 text-amber-100">
+                <div>
+                  <p className="text-3xl font-semibold text-white">{sampleListings.length}</p>
+                  <p className="text-sm uppercase tracking-wide">Active listings</p>
+                </div>
+                <div>
+                  <p className="text-3xl font-semibold text-white">{Object.keys(listingsByType).length}</p>
+                  <p className="text-sm uppercase tracking-wide">Categories</p>
+                </div>
+                <div>
+                  <p className="text-3xl font-semibold text-white">24/7</p>
+                  <p className="text-sm uppercase tracking-wide">Community support</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="hidden lg:block">
+              <div className="grid grid-cols-2 gap-4">
+                {sampleListings.slice(0, 4).map((listing) => (
+                  <div key={listing.id} className="bg-white/10 rounded-2xl p-4 backdrop-blur">
+                    <div className="relative h-32 rounded-xl overflow-hidden mb-4">
+                      <Image src={listing.image} alt={listing.title} fill className="object-cover" />
+                    </div>
+                    <p className="text-sm uppercase text-amber-200 font-semibold">{listingTypeLabels[listing.type].label}</p>
+                    <p className="font-semibold text-white">{listing.title}</p>
+                    <p className="text-sm text-amber-100">{formatCurrency(listing.priceCents)}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 space-y-16">
+        {/* Post listing CTA */}
+        <section className="bg-white border border-gray-200 rounded-2xl p-6 flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-900">Share a listing with the UiQ network</h2>
+            <p className="text-gray-600 mt-2">
+              Housing, jobs, cultural experiences, and items find new homes faster when shared within community.
+            </p>
+          </div>
+          <Button size="lg">Post a new listing</Button>
+        </section>
+
+        {/* Listings by category */}
+        {Object.entries(listingsByType).map(([type, listings]) => (
+          <section key={type} className="space-y-8">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div>
+                <h2 className="text-3xl font-bold text-gray-900">{listingTypeLabels[type].label}</h2>
+                <p className="text-gray-600 mt-2">{listingTypeLabels[type].description}</p>
+              </div>
+              <Link href="/pricing" className="text-amber-700 font-semibold">
+                Boost this listing →
+              </Link>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+              {listings.map((listing) => (
+                <Card key={listing.id} hoverable>
+                  <div className="relative h-48 w-full overflow-hidden rounded-t-2xl">
+                    <Image src={listing.image} alt={listing.title} fill className="object-cover" />
+                    <div className="absolute top-4 left-4 bg-white/90 backdrop-blur px-3 py-1 rounded-full text-xs font-semibold text-amber-700">
+                      {listingTypeLabels[listing.type].label}
+                    </div>
+                    <div className="absolute bottom-4 right-4 bg-amber-600 text-white px-3 py-1 rounded-full text-sm font-semibold">
+                      {formatCurrency(listing.priceCents)}
+                    </div>
+                  </div>
+                  <CardHeader>
+                    <CardTitle className="text-xl leading-snug">{listing.title}</CardTitle>
+                    <p className="text-sm text-gray-500">{formatRelativeTime(listing.postedAt)}</p>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <p className="text-gray-700 line-clamp-3">{listing.description}</p>
+                    <div className="flex items-center justify-between text-sm text-gray-600">
+                      <span>📍 {listing.location}</span>
+                      <span>Secure payments available</span>
+                    </div>
+                    <Link href={`/classifieds/${listing.slug}`} className="inline-flex items-center text-amber-700 font-semibold">
+                      View listing
+                      <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    </Link>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        {/* Safety tips */}
+        <section className="bg-white border border-gray-200 rounded-2xl p-8">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Community marketplace safety</h2>
+              <p className="text-gray-600 mt-1">
+                Every listing is moderated to keep members safe. Follow these tips when meeting buyers or sellers.
+              </p>
+            </div>
+            <Link href="/community" className="text-amber-700 font-semibold">
+              View all guidelines →
+            </Link>
+          </div>
+          <div className="grid md:grid-cols-2 gap-6 text-sm text-gray-700">
+            <div className="p-4 rounded-xl bg-amber-50 border border-amber-100">
+              <p className="font-semibold text-amber-800 mb-2">Meet in safe, public places</p>
+              <p>Prefer daytime meetups and let a friend or family member know your plans.</p>
+            </div>
+            <div className="p-4 rounded-xl bg-amber-50 border border-amber-100">
+              <p className="font-semibold text-amber-800 mb-2">Verify payments before handing over items</p>
+              <p>Use secure bank transfers or cash and confirm receipt before completing the exchange.</p>
+            </div>
+            <div className="p-4 rounded-xl bg-amber-50 border border-amber-100">
+              <p className="font-semibold text-amber-800 mb-2">Report suspicious behaviour</p>
+              <p>Flag listings or users that seem fraudulent so moderators can keep everyone safe.</p>
+            </div>
+            <div className="p-4 rounded-xl bg-amber-50 border border-amber-100">
+              <p className="font-semibold text-amber-800 mb-2">Respect cultural values</p>
+              <p>Be kind, punctual, and honour commitments to strengthen trust in our marketplace.</p>
+            </div>
+          </div>
+        </section>
+      </div>
     </MainLayout>
   )
 }

--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -1,10 +1,198 @@
+import Image from 'next/image'
+import Link from 'next/link'
 import { MainLayout } from '@/components/layout/MainLayout'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
+import { formatRelativeTime } from '@/lib/utils'
+import { sampleBusinesses, sampleEvents } from '@/data/sample-content'
 
 export default function DirectoryPage() {
+  const categories = Array.from(new Set(sampleBusinesses.map((business) => business.category))).sort()
+  const featuredBusinesses = sampleBusinesses
+  const upcomingEvents = sampleEvents.slice(0, 2)
+
   return (
-    <MainLayout className="p-8">
-      <h1 className="text-3xl font-bold">Directory</h1>
-      <p className="mt-4">Browse community businesses and organizations.</p>
+    <MainLayout className="bg-neutral-50">
+      {/* Hero */}
+      <section className="bg-gradient-to-r from-primary-600 to-primary-800 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+          <div className="grid lg:grid-cols-2 gap-12 items-center">
+            <div>
+              <Badge variant="featured" size="sm" className="mb-4 bg-white/10 text-white border-white/20">
+                UiQ Business Directory
+              </Badge>
+              <h1 className="text-4xl md:text-5xl font-bold mb-4">
+                Discover trusted Ugandan-owned businesses across Queensland
+              </h1>
+              <p className="text-lg text-primary-100 mb-8">
+                Explore professional services, cultural experiences, and community-led organisations that understand our
+                community.
+              </p>
+
+              <form action="/search" method="GET" className="bg-white/10 backdrop-blur rounded-xl p-2 flex flex-col sm:flex-row gap-2">
+                <input
+                  type="search"
+                  name="q"
+                  placeholder="Search by business name or service"
+                  className="flex-1 px-4 py-3 rounded-lg text-gray-900 focus:outline-none"
+                />
+                <Button type="submit" className="shrink-0">
+                  Search directory
+                </Button>
+              </form>
+
+              <div className="mt-8 flex flex-wrap gap-6 text-primary-100">
+                <div>
+                  <p className="text-3xl font-semibold text-white">{featuredBusinesses.length}</p>
+                  <p className="text-sm uppercase tracking-wide">Verified businesses</p>
+                </div>
+                <div>
+                  <p className="text-3xl font-semibold text-white">{categories.length}</p>
+                  <p className="text-sm uppercase tracking-wide">Service categories</p>
+                </div>
+                <div>
+                  <p className="text-3xl font-semibold text-white">{upcomingEvents.length}</p>
+                  <p className="text-sm uppercase tracking-wide">Community meetups</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="hidden lg:block">
+              <div className="grid grid-cols-2 gap-6">
+                {featuredBusinesses.slice(0, 4).map((business) => (
+                  <div key={business.id} className="bg-white/10 rounded-2xl p-4 backdrop-blur">
+                    <div className="relative h-32 rounded-xl overflow-hidden mb-4">
+                      <Image src={business.image} alt={business.name} fill className="object-cover" />
+                    </div>
+                    <p className="text-sm uppercase text-primary-200 font-semibold">{business.category}</p>
+                    <p className="font-semibold text-white">{business.name}</p>
+                    <p className="text-sm text-primary-100">{business.location}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 space-y-16">
+        {/* Categories */}
+        <section>
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6 mb-8">
+            <div>
+              <h2 className="text-3xl font-bold text-gray-900">Browse by service</h2>
+              <p className="text-gray-600 mt-2">
+                From hospitality to home care, find providers who speak our language and understand our culture.
+              </p>
+            </div>
+            <Link href="/groups" className="text-primary-600 font-semibold">
+              Request a new category →
+            </Link>
+          </div>
+
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {categories.map((category) => (
+              <div key={category} className="bg-white border border-gray-200 rounded-xl p-5 hover:border-primary-300 hover:shadow-card-hover transition">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-lg font-semibold text-gray-900">{category}</h3>
+                  <Badge variant="outline" className="text-primary-600 border-primary-200">
+                    {featuredBusinesses.filter((business) => business.category === category).length} listed
+                  </Badge>
+                </div>
+                <p className="text-sm text-gray-600 mt-3">
+                  Trusted professionals ready to support Ugandan families and businesses across Queensland.
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Featured businesses */}
+        <section>
+          <div className="flex items-center justify-between mb-8">
+            <div>
+              <h2 className="text-3xl font-bold text-gray-900">Featured businesses</h2>
+              <p className="text-gray-600 mt-2">
+                Handpicked members of our community delivering excellent service and cultural care.
+              </p>
+            </div>
+            <Link href="/pricing">
+              <Button variant="outline">List your business</Button>
+            </Link>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {featuredBusinesses.map((business) => (
+              <Card key={business.id} hoverable>
+                <CardHeader>
+                  <div className="flex items-center gap-4">
+                    <div className="relative h-14 w-14 rounded-xl overflow-hidden">
+                      <Image src={business.image} alt={business.name} fill className="object-cover" />
+                    </div>
+                    <div className="flex-1">
+                      <CardTitle className="text-xl">{business.name}</CardTitle>
+                      <p className="text-sm text-gray-600">{business.location}</p>
+                    </div>
+                    {business.verified && <Badge variant="verified">Verified</Badge>}
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <p className="text-sm font-semibold text-primary-600">{business.category}</p>
+                  <p className="text-gray-700 line-clamp-3">{business.description}</p>
+                  <div className="flex items-center justify-between text-sm text-gray-600">
+                    <span>⭐ {business.ratingAvg.toFixed(1)} ({business.ratingCount} reviews)</span>
+                    <span>{business.plan} plan</span>
+                  </div>
+                  <Link href={`/directory/${business.slug}`} className="inline-flex items-center text-primary-600 font-semibold">
+                    View profile
+                    <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </Link>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* Upcoming events */}
+        <section className="bg-white border border-gray-200 rounded-2xl p-8">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6 mb-8">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Meet the community offline</h2>
+              <p className="text-gray-600 mt-2">
+                Connect with other business owners and families at upcoming UiQ gatherings.
+              </p>
+            </div>
+            <Link href="/events">
+              <Button variant="outline">View all events</Button>
+            </Link>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-6">
+            {upcomingEvents.map((event) => (
+              <div key={event.id} className="flex gap-4 p-5 border border-gray-100 rounded-xl hover:border-primary-200 transition">
+                <div className="flex-shrink-0 text-center bg-primary-50 rounded-xl px-4 py-3">
+                  <p className="text-2xl font-bold text-primary-700">{new Date(event.startAt).getDate()}</p>
+                  <p className="text-xs uppercase tracking-wider text-primary-600">
+                    {new Date(event.startAt).toLocaleDateString('en-AU', { month: 'short' })}
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <p className="text-sm font-semibold text-primary-600">{event.category}</p>
+                  <h3 className="text-lg font-semibold text-gray-900">{event.title}</h3>
+                  <p className="text-sm text-gray-600 line-clamp-2">{event.description}</p>
+                  <div className="text-sm text-gray-500">
+                    <p>📍 {event.venue}</p>
+                    <p>⏰ {formatRelativeTime(event.startAt)}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
     </MainLayout>
   )
 }

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,10 +1,177 @@
+import Image from 'next/image'
+import Link from 'next/link'
 import { MainLayout } from '@/components/layout/MainLayout'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
+import { formatCurrency, formatDate, formatDateTime } from '@/lib/utils'
+import { sampleEvents } from '@/data/sample-content'
 
 export default function EventsPage() {
+  const categories = Array.from(new Set(sampleEvents.map((event) => event.category)))
+
   return (
-    <MainLayout className="p-8">
-      <h1 className="text-3xl font-bold">Events</h1>
-      <p className="mt-4">Find upcoming community events and gatherings.</p>
+    <MainLayout className="bg-neutral-50">
+      {/* Hero */}
+      <section className="bg-gradient-to-r from-secondary-700 via-secondary-600 to-secondary-500 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+          <div className="grid lg:grid-cols-2 gap-12 items-center">
+            <div>
+              <Badge variant="featured" size="sm" className="mb-4 bg-white/10 text-white border-white/20">
+                UiQ Events & Gatherings
+              </Badge>
+              <h1 className="text-4xl md:text-5xl font-bold mb-4">Celebrate, connect, and grow together</h1>
+              <p className="text-lg text-secondary-100 mb-8">
+                Discover cultural celebrations, professional meetups, and family-friendly gatherings hosted by the Ugandan
+                community across Queensland.
+              </p>
+
+              <div className="flex flex-wrap gap-4 text-secondary-100">
+                <div>
+                  <p className="text-3xl font-semibold text-white">{sampleEvents.length}</p>
+                  <p className="text-sm uppercase tracking-wide">Upcoming events</p>
+                </div>
+                <div>
+                  <p className="text-3xl font-semibold text-white">{categories.length}</p>
+                  <p className="text-sm uppercase tracking-wide">Themes & focus areas</p>
+                </div>
+                <div>
+                  <p className="text-3xl font-semibold text-white">100%</p>
+                  <p className="text-sm uppercase tracking-wide">Community-led</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="hidden lg:block">
+              <div className="grid grid-cols-2 gap-4">
+                {sampleEvents.slice(0, 2).map((event) => (
+                  <div key={event.id} className="bg-white/10 rounded-2xl p-4 backdrop-blur">
+                    <div className="relative h-36 rounded-xl overflow-hidden mb-4">
+                      <Image src={event.image} alt={event.title} fill className="object-cover" />
+                    </div>
+                    <p className="text-sm uppercase text-secondary-200 font-semibold">{event.category}</p>
+                    <p className="font-semibold text-white">{event.title}</p>
+                    <p className="text-sm text-secondary-100">{formatDate(event.startAt)}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 space-y-16">
+        {/* Category filters */}
+        <section className="bg-white border border-gray-200 rounded-2xl p-6">
+          <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
+            <div>
+              <h2 className="text-2xl font-semibold text-gray-900">Explore by interest</h2>
+              <p className="text-gray-600 mt-1">Events tailored for professionals, families, students, and creatives.</p>
+            </div>
+            <Link href="/announcements" className="text-secondary-700 font-semibold">
+              Submit an event →
+            </Link>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {categories.map((category) => (
+              <span
+                key={category}
+                className="px-4 py-2 rounded-full border border-secondary-200 text-secondary-700 bg-secondary-50 text-sm font-medium"
+              >
+                {category}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        {/* Events grid */}
+        <section className="space-y-8">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <h2 className="text-3xl font-bold text-gray-900">Upcoming gatherings</h2>
+              <p className="text-gray-600 mt-2">
+                Save your spot, invite friends, and be part of the Ugandan heartbeat in Queensland.
+              </p>
+            </div>
+            <Link href="/groups">
+              <Button variant="outline">Start a community group</Button>
+            </Link>
+          </div>
+
+          <div className="grid gap-8 md:grid-cols-2">
+            {sampleEvents.map((event) => (
+              <Card key={event.id} hoverable>
+                <div className="relative h-56 w-full overflow-hidden rounded-t-2xl">
+                  <Image src={event.image} alt={event.title} fill className="object-cover" />
+                  <div className="absolute top-4 left-4 bg-white/90 backdrop-blur rounded-lg px-4 py-2 text-center">
+                    <p className="text-xl font-semibold text-secondary-700">
+                      {new Date(event.startAt).toLocaleDateString('en-AU', { day: '2-digit' })}
+                    </p>
+                    <p className="text-xs uppercase tracking-wider text-secondary-500">
+                      {new Date(event.startAt).toLocaleDateString('en-AU', { month: 'short' })}
+                    </p>
+                  </div>
+                  {event.priceCents === 0 ? (
+                    <Badge variant="featured" className="absolute top-4 right-4">
+                      Free
+                    </Badge>
+                  ) : (
+                    <div className="absolute top-4 right-4 bg-secondary-600 text-white px-3 py-1 rounded-full text-sm font-semibold">
+                      {formatCurrency(event.priceCents)}
+                    </div>
+                  )}
+                </div>
+                <CardHeader>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Badge variant="outline" className="border-secondary-200 text-secondary-700">
+                      {event.category}
+                    </Badge>
+                    <span className="text-sm text-gray-500">Hosted by {event.organiser}</span>
+                  </div>
+                  <CardTitle className="text-2xl leading-snug">{event.title}</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <p className="text-gray-700 leading-relaxed">{event.description}</p>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-gray-600">
+                    <div>
+                      <p className="font-semibold text-gray-800">Date & time</p>
+                      <p>{formatDateTime(event.startAt)}</p>
+                      <p>{formatDateTime(event.endAt)}</p>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-gray-800">Location</p>
+                      <p>{event.venue}</p>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <span className="text-sm text-gray-500">Doors open 30 minutes before start time</span>
+                    <Link href={`/events/${event.slug}`} className="inline-flex items-center text-secondary-700 font-semibold">
+                      View details
+                      <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    </Link>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* Call to action */}
+        <section className="bg-secondary-700 text-white rounded-3xl px-8 py-12 flex flex-col md:flex-row md:items-center md:justify-between gap-8">
+          <div>
+            <h2 className="text-3xl font-bold mb-3">Host a gathering with UiQ support</h2>
+            <p className="text-secondary-100 max-w-2xl">
+              Planning a meetup, workshop, or celebration? Share the details with us and we will help promote it across the
+              UiQ community.
+            </p>
+          </div>
+          <Button size="lg" variant="outline" className="text-white border-white hover:bg-white/10">
+            Submit event details
+          </Button>
+        </section>
+      </div>
     </MainLayout>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,12 @@ import { Button } from '@/components/ui/Button'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
 import { Badge } from '@/components/ui/Badge'
 import { formatCurrency, formatDate } from '@/lib/utils'
+import {
+  sampleAnnouncements,
+  sampleBusinesses,
+  sampleEvents,
+  sampleListings
+} from '@/data/sample-content'
 
 async function getFeaturedData() {
   try {
@@ -39,11 +45,37 @@ async function getFeaturedData() {
       })
     ])
 
-    return { businesses, events, announcements, listings }
+    const hasContent =
+      businesses.length > 0 ||
+      events.length > 0 ||
+      announcements.length > 0 ||
+      listings.length > 0
+
+    if (hasContent) {
+      return { businesses, events, announcements, listings }
+    }
   } catch (error) {
     console.error('Failed to load featured content from Prisma. Returning empty collections.', error)
+  }
 
-    return { businesses: [], events: [], announcements: [], listings: [] }
+  // Fallback to curated sample content so the homepage never renders empty
+  return {
+    businesses: sampleBusinesses.map((business) => ({
+      ...business,
+      owner: { name: 'UiQ Community' }
+    })),
+    events: sampleEvents.map((event) => ({
+      ...event,
+      organiser: { name: event.organiser }
+    })),
+    announcements: sampleAnnouncements.map((announcement) => ({
+      ...announcement,
+      author: { name: announcement.author }
+    })),
+    listings: sampleListings.map((listing) => ({
+      ...listing,
+      owner: { name: 'UiQ Community' }
+    }))
   }
 }
 

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -2,7 +2,7 @@
 import { cn } from '@/lib/utils'
 
 export interface BadgeProps {
-  variant?: 'verified' | 'premium' | 'member-plus' | 'new' | 'featured' | 'urgent'
+  variant?: 'verified' | 'premium' | 'member-plus' | 'new' | 'featured' | 'urgent' | 'outline'
   size?: 'sm' | 'md' | 'lg'
   className?: string
   children: React.ReactNode
@@ -17,7 +17,8 @@ const Badge = ({ variant = 'verified', size = 'md', className, children }: Badge
     'member-plus': 'bg-primary-100 text-primary-700 border border-primary-200',
     new: 'bg-info-100 text-info-700 border border-info-200',
     featured: 'bg-accent-100 text-accent-700 border border-accent-300',
-    urgent: 'bg-error-100 text-error-700 border border-error-200'
+    urgent: 'bg-error-100 text-error-700 border border-error-200',
+    outline: 'bg-white text-accent-700 border border-accent-200'
   }
   
   const sizes = {
@@ -32,7 +33,8 @@ const Badge = ({ variant = 'verified', size = 'md', className, children }: Badge
     'member-plus': '♦',
     new: '•',
     featured: '◆',
-    urgent: '!'
+    urgent: '!',
+    outline: '∘'
   }
 
   return (

--- a/src/data/sample-content.ts
+++ b/src/data/sample-content.ts
@@ -1,0 +1,275 @@
+export interface SampleBusiness {
+  id: string
+  name: string
+  slug: string
+  category: string
+  description: string
+  ratingAvg: number
+  ratingCount: number
+  verified: boolean
+  plan: 'Basic' | 'Standard' | 'Premium'
+  location: string
+  image: string
+}
+
+export interface SampleEvent {
+  id: string
+  title: string
+  slug: string
+  category: string
+  description: string
+  startAt: string
+  endAt: string
+  venue: string
+  priceCents: number
+  image: string
+  organiser: string
+}
+
+export interface SampleAnnouncement {
+  id: string
+  title: string
+  body: string
+  type: string
+  author: string
+  publishedAt: string
+}
+
+export interface SampleListing {
+  id: string
+  title: string
+  slug: string
+  type: 'sale' | 'housing' | 'gig'
+  description: string
+  priceCents: number
+  location: string
+  image: string
+  postedAt: string
+}
+
+export const sampleBusinesses: SampleBusiness[] = [
+  {
+    id: 'biz1',
+    name: "Nakato's African Cuisine",
+    slug: 'nakatos-african-cuisine',
+    category: 'Restaurant',
+    description:
+      'Authentic Ugandan and East African dishes made with love. Specializing in matoke, posho, groundnut stew, and rolex.',
+    ratingAvg: 4.9,
+    ratingCount: 24,
+    verified: true,
+    plan: 'Premium',
+    location: 'South Brisbane',
+    image: 'https://images.unsplash.com/photo-1567620905732-2d1ec7ab7445?w=600&h=400&fit=crop&auto=format'
+  },
+  {
+    id: 'biz2',
+    name: 'Mukasa Auto Services',
+    slug: 'mukasa-auto-services',
+    category: 'Mechanic',
+    description:
+      'Professional automotive repair and maintenance services. Specializing in pre-purchase inspections and roadworthy certificates.',
+    ratingAvg: 4.8,
+    ratingCount: 18,
+    verified: true,
+    plan: 'Standard',
+    location: 'Toowoomba',
+    image: 'https://images.unsplash.com/photo-1632823471565-1ecdf2df44b2?w=600&h=400&fit=crop&auto=format'
+  },
+  {
+    id: 'biz3',
+    name: 'Uganda Tech Solutions',
+    slug: 'uganda-tech-solutions',
+    category: 'IT Services',
+    description:
+      'IT support and digital solutions for small businesses and individuals. Computer repairs, website development, and tech consulting.',
+    ratingAvg: 4.7,
+    ratingCount: 15,
+    verified: true,
+    plan: 'Standard',
+    location: 'Brisbane CBD',
+    image: 'https://images.unsplash.com/photo-1581291518857-4e27b48ff24e?w=600&h=400&fit=crop&auto=format'
+  },
+  {
+    id: 'biz4',
+    name: 'Kaggwa Cleaning Collective',
+    slug: 'kaggwa-cleaning-collective',
+    category: 'Cleaning',
+    description:
+      'Reliable residential and commercial cleaning services with eco-friendly products and flexible schedules.',
+    ratingAvg: 4.6,
+    ratingCount: 32,
+    verified: true,
+    plan: 'Premium',
+    location: 'Logan',
+    image: 'https://images.unsplash.com/photo-1581578731548-c64695cc6952?w=600&h=400&fit=crop&auto=format'
+  },
+  {
+    id: 'biz5',
+    name: 'Sanyu Family Daycare',
+    slug: 'sanyu-family-daycare',
+    category: 'Childcare',
+    description:
+      'Warm and inclusive family daycare with a focus on Ugandan culture, language, and healthy meals for little ones.',
+    ratingAvg: 4.95,
+    ratingCount: 41,
+    verified: true,
+    plan: 'Premium',
+    location: 'Ipswich',
+    image: 'https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=600&h=400&fit=crop&auto=format'
+  },
+  {
+    id: 'biz6',
+    name: 'Queensland Ugandan Nurses Network',
+    slug: 'queensland-ugandan-nurses-network',
+    category: 'Healthcare',
+    description:
+      'Experienced nurses offering in-home care, medication management, and wellbeing support for families across Queensland.',
+    ratingAvg: 4.85,
+    ratingCount: 27,
+    verified: true,
+    plan: 'Standard',
+    location: 'Gold Coast',
+    image: 'https://images.unsplash.com/photo-1587502537745-84ab0f4d2b71?w=600&h=400&fit=crop&auto=format'
+  }
+]
+
+export const sampleEvents: SampleEvent[] = [
+  {
+    id: 'evt1',
+    title: "Uganda Independence Day Celebration 2024",
+    slug: 'uganda-independence-day-2024',
+    category: 'Cultural',
+    description:
+      "Join us for a spectacular celebration of Uganda's Independence Day! Traditional music, dance performances, authentic food stalls, and cultural activities for the whole family.",
+    startAt: '2024-10-09T14:00:00+10:00',
+    endAt: '2024-10-09T20:00:00+10:00',
+    venue: 'Musgrave Park, South Brisbane QLD',
+    priceCents: 0,
+    image: 'https://images.unsplash.com/photo-1533174072545-7a4b6ad7a6c3?w=900&h=600&fit=crop&auto=format',
+    organiser: 'UiQ Community'
+  },
+  {
+    id: 'evt2',
+    title: 'UiQ Business Networking Mixer',
+    slug: 'uiq-business-networking-mixer',
+    category: 'Business',
+    description:
+      'Monthly networking event for Ugandan business owners and professionals in Queensland. Connect, share experiences, and grow your network.',
+    startAt: '2024-09-20T18:00:00+10:00',
+    endAt: '2024-09-20T21:00:00+10:00',
+    venue: 'Brisbane Convention Centre, South Brisbane',
+    priceCents: 2500,
+    image: 'https://images.unsplash.com/photo-1511795409834-ef04bbd61622?w=900&h=600&fit=crop&auto=format',
+    organiser: 'UiQ Business Circle'
+  },
+  {
+    id: 'evt3',
+    title: 'Education Workshop: Navigating Australian Schools',
+    slug: 'education-workshop-australian-schools',
+    category: 'Education',
+    description:
+      'Free workshop for Ugandan families navigating the Australian education system. Learn about school applications, NAPLAN, and scholarship opportunities.',
+    startAt: '2024-09-15T10:00:00+10:00',
+    endAt: '2024-09-15T15:00:00+10:00',
+    venue: 'Brisbane City Library, Brisbane CBD',
+    priceCents: 0,
+    image: 'https://images.unsplash.com/photo-1523050854058-8df90110c9d1?w=900&h=600&fit=crop&auto=format',
+    organiser: 'UiQ Education Collective'
+  },
+  {
+    id: 'evt4',
+    title: 'Queensland Community Picnic',
+    slug: 'queensland-community-picnic',
+    category: 'Community',
+    description:
+      'Bring your family and favourite dishes for a relaxed community picnic. Games for kids, drum circles, and storytelling corner.',
+    startAt: '2024-10-05T11:00:00+10:00',
+    endAt: '2024-10-05T16:00:00+10:00',
+    venue: 'Roma Street Parklands, Brisbane',
+    priceCents: 0,
+    image: 'https://images.unsplash.com/photo-1521334884684-d80222895322?w=900&h=600&fit=crop&auto=format',
+    organiser: 'UiQ Families'
+  }
+]
+
+export const sampleAnnouncements: SampleAnnouncement[] = [
+  {
+    id: 'ann1',
+    title: 'Celebrating Dr. Auma for Community Service',
+    body:
+      'Join us in congratulating Dr. Grace Auma for receiving the Queensland Community Leadership Award for her outstanding contribution to Ugandan families across the state.',
+    type: 'ACHIEVEMENT',
+    author: 'UiQ Leadership Team',
+    publishedAt: '2024-08-01T09:00:00+10:00'
+  },
+  {
+    id: 'ann2',
+    title: 'Bereavement Notice: In Memory of Mr. Kato',
+    body:
+      'We are saddened to announce the passing of Mr. John Kato. A memorial service will be held on 18 August at St. Stephen\'s Cathedral, Brisbane. Please keep the family in your prayers.',
+    type: 'BEREAVEMENT',
+    author: 'UiQ Care Team',
+    publishedAt: '2024-08-05T08:30:00+10:00'
+  },
+  {
+    id: 'ann3',
+    title: 'Scholarship Applications Now Open',
+    body:
+      'Applications are now open for the 2025 UiQ Youth Scholarships supporting Ugandan students in Queensland. Submit your application before 30 September.',
+    type: 'NOTICE',
+    author: 'UiQ Education Committee',
+    publishedAt: '2024-07-28T12:00:00+10:00'
+  }
+]
+
+export const sampleListings: SampleListing[] = [
+  {
+    id: 'list1',
+    title: 'Fully Furnished Room in South Brisbane',
+    slug: 'furnished-room-south-brisbane',
+    type: 'housing',
+    description:
+      'Sunny private room available in a Ugandan household. Includes utilities, Wi-Fi, and access to public transport. Female housemates preferred.',
+    priceCents: 22000,
+    location: 'South Brisbane',
+    image: 'https://images.unsplash.com/photo-1505691938895-1758d7feb511?w=900&h=600&fit=crop&auto=format',
+    postedAt: '2024-08-10T10:00:00+10:00'
+  },
+  {
+    id: 'list2',
+    title: 'Traditional Drumming for Events',
+    slug: 'traditional-drumming-for-events',
+    type: 'gig',
+    description:
+      'Experienced troupe available for weddings, cultural events, and school performances. Includes instruments and colourful costumes.',
+    priceCents: 45000,
+    location: 'Greater Brisbane',
+    image: 'https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=900&h=600&fit=crop&auto=format',
+    postedAt: '2024-08-08T14:30:00+10:00'
+  },
+  {
+    id: 'list3',
+    title: 'Ugandan Food Catering Package',
+    slug: 'ugandan-food-catering-package',
+    type: 'sale',
+    description:
+      'Catering for up to 80 guests including luwombo, matoke, pilau, and vegetarian options. Perfect for celebrations and church functions.',
+    priceCents: 120000,
+    location: 'Logan',
+    image: 'https://images.unsplash.com/photo-1498837167922-ddd27525d352?w=900&h=600&fit=crop&auto=format',
+    postedAt: '2024-08-03T09:15:00+10:00'
+  },
+  {
+    id: 'list4',
+    title: 'Second-hand Baby Essentials Bundle',
+    slug: 'baby-essentials-bundle',
+    type: 'sale',
+    description:
+      'Bundle includes cot, stroller, baby carrier, and toys in great condition. Pickup available in Ipswich on weekends.',
+    priceCents: 18000,
+    location: 'Ipswich',
+    image: 'https://images.unsplash.com/photo-1519681393784-d120267933ba?w=900&h=600&fit=crop&auto=format',
+    postedAt: '2024-08-11T16:45:00+10:00'
+  }
+]


### PR DESCRIPTION
## Summary
- add a shared set of curated sample businesses, events, announcements, and listings so pages always have meaningful data
- rebuild the directory, events, classifieds, and announcements screens with full hero, grid, and support sections driven by the curated content
- extend the badge component with an outline style used by the refreshed page layouts

## Testing
- npm run lint *(fails: existing lint warnings/errors in untouched auth and ui files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbed0248b0832bad8ee409a792a4ba