### PR TITLE
feat: add initial drizzle schema and migrations

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "drizzle-kit";
+
+const connectionString =
+  process.env.DATABASE_URL ||
+  process.env.POSTGRES_URL ||
+  process.env.POSTGRES_CONNECTION_STRING ||
+  process.env.NEON_DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error(
+    "DATABASE_URL (or POSTGRES_URL/POSTGRES_CONNECTION_STRING/NEON_DATABASE_URL) must be set to run Drizzle migrations.",
+  );
+}
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./shared/schema.ts",
+  out: "./drizzle",
+  strict: true,
+  dbCredentials: {
+    url: connectionString,
+  },
+});

--- a/drizzle/0000_quiet_major_mapleleaf.sql
+++ b/drizzle/0000_quiet_major_mapleleaf.sql
@@ -1,0 +1,335 @@
+CREATE TABLE "announcements" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"author_id" uuid NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"body" text NOT NULL,
+	"type" varchar(32) DEFAULT 'general' NOT NULL,
+	"audience" varchar(32) DEFAULT 'public' NOT NULL,
+	"published_at" timestamp with time zone,
+	"expires_at" timestamp with time zone,
+	"attachments" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "announcements_type_check" CHECK ("announcements"."type" in ('general', 'bereavement', 'urgent', 'celebration')),
+	CONSTRAINT "announcements_audience_check" CHECK ("announcements"."audience" in ('public', 'members', 'admins'))
+);
+--> statement-breakpoint
+CREATE TABLE "business_reviews" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"business_id" uuid NOT NULL,
+	"author_id" uuid NOT NULL,
+	"rating" integer NOT NULL,
+	"title" varchar(255),
+	"body" text,
+	"status" varchar(32) DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	CONSTRAINT "business_reviews_status_check" CHECK ("business_reviews"."status" in ('pending', 'published', 'removed')),
+	CONSTRAINT "business_reviews_rating_check" CHECK ("business_reviews"."rating" between 1 and 5)
+);
+--> statement-breakpoint
+CREATE TABLE "businesses" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"owner_id" uuid NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"slug" varchar(255) NOT NULL,
+	"description" text,
+	"category" varchar(120) NOT NULL,
+	"status" varchar(32) DEFAULT 'draft' NOT NULL,
+	"plan" varchar(32) DEFAULT 'basic' NOT NULL,
+	"email" varchar(255),
+	"phone" varchar(32),
+	"website" varchar(512),
+	"address_line1" varchar(255),
+	"address_line2" varchar(255),
+	"city" varchar(120),
+	"state" varchar(120),
+	"postal_code" varchar(32),
+	"country" varchar(120),
+	"latitude" numeric(9, 6),
+	"longitude" numeric(9, 6),
+	"tags" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"hours" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "businesses_status_check" CHECK ("businesses"."status" in ('draft', 'review', 'published', 'archived')),
+	CONSTRAINT "businesses_plan_check" CHECK ("businesses"."plan" in ('basic', 'standard', 'premium'))
+);
+--> statement-breakpoint
+CREATE TABLE "classifieds" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"owner_id" uuid NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"description" text NOT NULL,
+	"type" varchar(32) DEFAULT 'offer' NOT NULL,
+	"status" varchar(32) DEFAULT 'draft' NOT NULL,
+	"category" varchar(120),
+	"price" numeric(12, 2),
+	"currency" varchar(3) DEFAULT 'USD',
+	"location" varchar(255),
+	"expires_at" timestamp with time zone,
+	"contact_info" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "classifieds_status_check" CHECK ("classifieds"."status" in ('draft', 'published', 'archived')),
+	CONSTRAINT "classifieds_type_check" CHECK ("classifieds"."type" in ('offer', 'request'))
+);
+--> statement-breakpoint
+CREATE TABLE "conversations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_by" uuid NOT NULL,
+	"topic" varchar(255),
+	"is_group" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organizer_id" uuid NOT NULL,
+	"business_id" uuid,
+	"title" varchar(255) NOT NULL,
+	"description" text,
+	"status" varchar(32) DEFAULT 'draft' NOT NULL,
+	"visibility" varchar(32) DEFAULT 'public' NOT NULL,
+	"capacity" integer,
+	"rsvp_deadline" timestamp with time zone,
+	"location_name" varchar(255),
+	"address" text,
+	"latitude" numeric(9, 6),
+	"longitude" numeric(9, 6),
+	"start_at" timestamp with time zone NOT NULL,
+	"end_at" timestamp with time zone,
+	"tags" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "events_visibility_check" CHECK ("events"."visibility" in ('public', 'members', 'private')),
+	CONSTRAINT "events_status_check" CHECK ("events"."status" in ('draft', 'published', 'cancelled'))
+);
+--> statement-breakpoint
+CREATE TABLE "messages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"conversation_id" uuid NOT NULL,
+	"sender_id" uuid NOT NULL,
+	"type" varchar(32) DEFAULT 'text' NOT NULL,
+	"status" varchar(32) DEFAULT 'sent' NOT NULL,
+	"body" text NOT NULL,
+	"attachments" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"delivered_at" timestamp with time zone,
+	"read_at" timestamp with time zone,
+	CONSTRAINT "messages_type_check" CHECK ("messages"."type" in ('text', 'image', 'file', 'system')),
+	CONSTRAINT "messages_status_check" CHECK ("messages"."status" in ('sent', 'delivered', 'read'))
+);
+--> statement-breakpoint
+CREATE TABLE "opportunities" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"owner_id" uuid NOT NULL,
+	"program_id" uuid,
+	"title" varchar(255) NOT NULL,
+	"description" text,
+	"type" varchar(32) DEFAULT 'job' NOT NULL,
+	"status" varchar(32) DEFAULT 'draft' NOT NULL,
+	"location" varchar(255),
+	"is_remote" boolean DEFAULT false NOT NULL,
+	"application_url" varchar(512),
+	"compensation" varchar(255),
+	"posted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"closes_at" timestamp with time zone,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	CONSTRAINT "opportunities_type_check" CHECK ("opportunities"."type" in ('scholarship', 'job', 'grant', 'volunteer', 'fellowship')),
+	CONSTRAINT "opportunities_status_check" CHECK ("opportunities"."status" in ('draft', 'open', 'closed'))
+);
+--> statement-breakpoint
+CREATE TABLE "participants" (
+	"conversation_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"role" varchar(32) DEFAULT 'member' NOT NULL,
+	"joined_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	CONSTRAINT "participants_pkey" PRIMARY KEY("conversation_id","user_id"),
+	CONSTRAINT "participants_role_check" CHECK ("participants"."role" in ('member', 'moderator'))
+);
+--> statement-breakpoint
+CREATE TABLE "profiles" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"display_name" varchar(160) NOT NULL,
+	"pronouns" varchar(80),
+	"bio" text,
+	"avatar_url" varchar(512),
+	"location" varchar(255),
+	"website_url" varchar(512),
+	"social_links" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"preferences" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "programs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"owner_id" uuid NOT NULL,
+	"business_id" uuid,
+	"title" varchar(255) NOT NULL,
+	"summary" varchar(512),
+	"description" text,
+	"category" varchar(120),
+	"status" varchar(32) DEFAULT 'draft' NOT NULL,
+	"start_at" timestamp with time zone,
+	"end_at" timestamp with time zone,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "programs_status_check" CHECK ("programs"."status" in ('draft', 'published', 'archived'))
+);
+--> statement-breakpoint
+CREATE TABLE "reports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"reporter_id" uuid NOT NULL,
+	"subject_type" varchar(32) NOT NULL,
+	"subject_id" uuid NOT NULL,
+	"reason" varchar(64) NOT NULL,
+	"status" varchar(32) DEFAULT 'pending' NOT NULL,
+	"details" text,
+	"resolution" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	CONSTRAINT "reports_subject_check" CHECK ("reports"."subject_type" in ('user', 'business', 'event', 'announcement', 'classified', 'message')),
+	CONSTRAINT "reports_status_check" CHECK ("reports"."status" in ('pending', 'reviewing', 'resolved', 'dismissed'))
+);
+--> statement-breakpoint
+CREATE TABLE "rsvps" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"status" varchar(32) DEFAULT 'pending' NOT NULL,
+	"guest_count" integer DEFAULT 1 NOT NULL,
+	"responded_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"notes" text,
+	CONSTRAINT "rsvps_status_check" CHECK ("rsvps"."status" in ('pending', 'confirmed', 'waitlisted', 'cancelled'))
+);
+--> statement-breakpoint
+CREATE TABLE "subscriptions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"business_id" uuid,
+	"plan" varchar(32) DEFAULT 'free' NOT NULL,
+	"status" varchar(32) DEFAULT 'active' NOT NULL,
+	"provider" varchar(64) NOT NULL,
+	"provider_customer_id" varchar(255),
+	"provider_subscription_id" varchar(255),
+	"trial_ends_at" timestamp with time zone,
+	"current_period_start" timestamp with time zone NOT NULL,
+	"current_period_end" timestamp with time zone NOT NULL,
+	"cancel_at" timestamp with time zone,
+	"canceled_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	CONSTRAINT "subscriptions_plan_check" CHECK ("subscriptions"."plan" in ('free', 'plus', 'family')),
+	CONSTRAINT "subscriptions_status_check" CHECK ("subscriptions"."status" in ('active', 'trialing', 'past_due', 'canceled', 'incomplete'))
+);
+--> statement-breakpoint
+CREATE TABLE "usage" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"scope" varchar(32) DEFAULT 'global' NOT NULL,
+	"user_id" uuid,
+	"business_id" uuid,
+	"feature" varchar(120) NOT NULL,
+	"action" varchar(120) NOT NULL,
+	"count" integer DEFAULT 0 NOT NULL,
+	"window_start" timestamp with time zone NOT NULL,
+	"window_end" timestamp with time zone NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "usage_scope_check" CHECK ("usage"."scope" in ('global', 'user', 'business'))
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"role" varchar(32) DEFAULT 'member' NOT NULL,
+	"status" varchar(32) DEFAULT 'active' NOT NULL,
+	"password_hash" varchar(255),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_sign_in_at" timestamp with time zone,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	CONSTRAINT "users_role_check" CHECK ("users"."role" in ('member', 'moderator', 'admin')),
+	CONSTRAINT "users_status_check" CHECK ("users"."status" in ('active', 'inactive', 'suspended'))
+);
+--> statement-breakpoint
+ALTER TABLE "announcements" ADD CONSTRAINT "announcements_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "business_reviews" ADD CONSTRAINT "business_reviews_business_id_businesses_id_fk" FOREIGN KEY ("business_id") REFERENCES "public"."businesses"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "business_reviews" ADD CONSTRAINT "business_reviews_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "businesses" ADD CONSTRAINT "businesses_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "classifieds" ADD CONSTRAINT "classifieds_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversations" ADD CONSTRAINT "conversations_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "events" ADD CONSTRAINT "events_organizer_id_users_id_fk" FOREIGN KEY ("organizer_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "events" ADD CONSTRAINT "events_business_id_businesses_id_fk" FOREIGN KEY ("business_id") REFERENCES "public"."businesses"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_sender_id_users_id_fk" FOREIGN KEY ("sender_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "opportunities" ADD CONSTRAINT "opportunities_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "opportunities" ADD CONSTRAINT "opportunities_program_id_programs_id_fk" FOREIGN KEY ("program_id") REFERENCES "public"."programs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "participants" ADD CONSTRAINT "participants_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "participants" ADD CONSTRAINT "participants_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "profiles" ADD CONSTRAINT "profiles_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "programs" ADD CONSTRAINT "programs_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "programs" ADD CONSTRAINT "programs_business_id_businesses_id_fk" FOREIGN KEY ("business_id") REFERENCES "public"."businesses"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reports" ADD CONSTRAINT "reports_reporter_id_users_id_fk" FOREIGN KEY ("reporter_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "rsvps" ADD CONSTRAINT "rsvps_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "rsvps" ADD CONSTRAINT "rsvps_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD CONSTRAINT "subscriptions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD CONSTRAINT "subscriptions_business_id_businesses_id_fk" FOREIGN KEY ("business_id") REFERENCES "public"."businesses"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "usage" ADD CONSTRAINT "usage_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "usage" ADD CONSTRAINT "usage_business_id_businesses_id_fk" FOREIGN KEY ("business_id") REFERENCES "public"."businesses"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "announcements_author_idx" ON "announcements" USING btree ("author_id");--> statement-breakpoint
+CREATE INDEX "announcements_published_idx" ON "announcements" USING btree ("published_at");--> statement-breakpoint
+CREATE INDEX "announcements_type_idx" ON "announcements" USING btree ("type");--> statement-breakpoint
+CREATE INDEX "business_reviews_business_idx" ON "business_reviews" USING btree ("business_id");--> statement-breakpoint
+CREATE INDEX "business_reviews_author_idx" ON "business_reviews" USING btree ("author_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "business_reviews_unique_reviewer" ON "business_reviews" USING btree ("business_id","author_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "businesses_slug_key" ON "businesses" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "businesses_owner_idx" ON "businesses" USING btree ("owner_id");--> statement-breakpoint
+CREATE INDEX "businesses_category_idx" ON "businesses" USING btree ("category");--> statement-breakpoint
+CREATE INDEX "businesses_status_idx" ON "businesses" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "classifieds_owner_idx" ON "classifieds" USING btree ("owner_id");--> statement-breakpoint
+CREATE INDEX "classifieds_status_idx" ON "classifieds" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "classifieds_type_idx" ON "classifieds" USING btree ("type");--> statement-breakpoint
+CREATE INDEX "conversations_created_by_idx" ON "conversations" USING btree ("created_by");--> statement-breakpoint
+CREATE INDEX "events_organizer_idx" ON "events" USING btree ("organizer_id");--> statement-breakpoint
+CREATE INDEX "events_business_idx" ON "events" USING btree ("business_id");--> statement-breakpoint
+CREATE INDEX "events_start_idx" ON "events" USING btree ("start_at");--> statement-breakpoint
+CREATE INDEX "events_status_idx" ON "events" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "messages_conversation_idx" ON "messages" USING btree ("conversation_id");--> statement-breakpoint
+CREATE INDEX "messages_sender_idx" ON "messages" USING btree ("sender_id");--> statement-breakpoint
+CREATE INDEX "messages_created_idx" ON "messages" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "opportunities_owner_idx" ON "opportunities" USING btree ("owner_id");--> statement-breakpoint
+CREATE INDEX "opportunities_program_idx" ON "opportunities" USING btree ("program_id");--> statement-breakpoint
+CREATE INDEX "opportunities_type_idx" ON "opportunities" USING btree ("type");--> statement-breakpoint
+CREATE INDEX "opportunities_status_idx" ON "opportunities" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "participants_user_idx" ON "participants" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "profiles_user_id_key" ON "profiles" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "profiles_display_name_idx" ON "profiles" USING btree ("display_name");--> statement-breakpoint
+CREATE INDEX "programs_owner_idx" ON "programs" USING btree ("owner_id");--> statement-breakpoint
+CREATE INDEX "programs_business_idx" ON "programs" USING btree ("business_id");--> statement-breakpoint
+CREATE INDEX "programs_status_idx" ON "programs" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "reports_reporter_idx" ON "reports" USING btree ("reporter_id");--> statement-breakpoint
+CREATE INDEX "reports_subject_idx" ON "reports" USING btree ("subject_type","subject_id");--> statement-breakpoint
+CREATE INDEX "reports_status_idx" ON "reports" USING btree ("status");--> statement-breakpoint
+CREATE UNIQUE INDEX "rsvps_unique_attendee" ON "rsvps" USING btree ("event_id","user_id");--> statement-breakpoint
+CREATE INDEX "rsvps_status_idx" ON "rsvps" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "subscriptions_user_idx" ON "subscriptions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "subscriptions_business_idx" ON "subscriptions" USING btree ("business_id");--> statement-breakpoint
+CREATE INDEX "subscriptions_status_idx" ON "subscriptions" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "usage_scope_idx" ON "usage" USING btree ("scope");--> statement-breakpoint
+CREATE INDEX "usage_window_idx" ON "usage" USING btree ("window_start");--> statement-breakpoint
+CREATE UNIQUE INDEX "usage_unique_window" ON "usage" USING btree ("scope","user_id","business_id","feature","action","window_start");--> statement-breakpoint
+CREATE UNIQUE INDEX "users_email_key" ON "users" USING btree ("email");--> statement-breakpoint
+CREATE INDEX "users_role_idx" ON "users" USING btree ("role");--> statement-breakpoint
+CREATE INDEX "users_status_idx" ON "users" USING btree ("status");

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,2657 @@
+{
+  "id": "08cc4865-7d47-42b9-8e88-175edbc0ce73",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_author_idx": {
+          "name": "announcements_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_published_idx": {
+          "name": "announcements_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_type_idx": {
+          "name": "announcements_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "announcements_author_id_users_id_fk": {
+          "name": "announcements_author_id_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "announcements_type_check": {
+          "name": "announcements_type_check",
+          "value": "\"announcements\".\"type\" in ('general', 'bereavement', 'urgent', 'celebration')"
+        },
+        "announcements_audience_check": {
+          "name": "announcements_audience_check",
+          "value": "\"announcements\".\"audience\" in ('public', 'members', 'admins')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.business_reviews": {
+      "name": "business_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "business_id": {
+          "name": "business_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "business_reviews_business_idx": {
+          "name": "business_reviews_business_idx",
+          "columns": [
+            {
+              "expression": "business_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_reviews_author_idx": {
+          "name": "business_reviews_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_reviews_unique_reviewer": {
+          "name": "business_reviews_unique_reviewer",
+          "columns": [
+            {
+              "expression": "business_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_reviews_business_id_businesses_id_fk": {
+          "name": "business_reviews_business_id_businesses_id_fk",
+          "tableFrom": "business_reviews",
+          "tableTo": "businesses",
+          "columnsFrom": [
+            "business_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "business_reviews_author_id_users_id_fk": {
+          "name": "business_reviews_author_id_users_id_fk",
+          "tableFrom": "business_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "business_reviews_status_check": {
+          "name": "business_reviews_status_check",
+          "value": "\"business_reviews\".\"status\" in ('pending', 'published', 'removed')"
+        },
+        "business_reviews_rating_check": {
+          "name": "business_reviews_rating_check",
+          "value": "\"business_reviews\".\"rating\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.businesses": {
+      "name": "businesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'basic'"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line2": {
+          "name": "address_line2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "hours": {
+          "name": "hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "businesses_slug_key": {
+          "name": "businesses_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "businesses_owner_idx": {
+          "name": "businesses_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "businesses_category_idx": {
+          "name": "businesses_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "businesses_status_idx": {
+          "name": "businesses_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "businesses_owner_id_users_id_fk": {
+          "name": "businesses_owner_id_users_id_fk",
+          "tableFrom": "businesses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "businesses_status_check": {
+          "name": "businesses_status_check",
+          "value": "\"businesses\".\"status\" in ('draft', 'review', 'published', 'archived')"
+        },
+        "businesses_plan_check": {
+          "name": "businesses_plan_check",
+          "value": "\"businesses\".\"plan\" in ('basic', 'standard', 'premium')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.classifieds": {
+      "name": "classifieds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_info": {
+          "name": "contact_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classifieds_owner_idx": {
+          "name": "classifieds_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "classifieds_status_idx": {
+          "name": "classifieds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "classifieds_type_idx": {
+          "name": "classifieds_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classifieds_owner_id_users_id_fk": {
+          "name": "classifieds_owner_id_users_id_fk",
+          "tableFrom": "classifieds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "classifieds_status_check": {
+          "name": "classifieds_status_check",
+          "value": "\"classifieds\".\"status\" in ('draft', 'published', 'archived')"
+        },
+        "classifieds_type_check": {
+          "name": "classifieds_type_check",
+          "value": "\"classifieds\".\"type\" in ('offer', 'request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "conversations_created_by_idx": {
+          "name": "conversations_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_created_by_users_id_fk": {
+          "name": "conversations_created_by_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_id": {
+          "name": "business_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_deadline": {
+          "name": "rsvp_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_organizer_idx": {
+          "name": "events_organizer_idx",
+          "columns": [
+            {
+              "expression": "organizer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_business_idx": {
+          "name": "events_business_idx",
+          "columns": [
+            {
+              "expression": "business_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_start_idx": {
+          "name": "events_start_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_status_idx": {
+          "name": "events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_organizer_id_users_id_fk": {
+          "name": "events_organizer_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_business_id_businesses_id_fk": {
+          "name": "events_business_id_businesses_id_fk",
+          "tableFrom": "events",
+          "tableTo": "businesses",
+          "columnsFrom": [
+            "business_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "events_visibility_check": {
+          "name": "events_visibility_check",
+          "value": "\"events\".\"visibility\" in ('public', 'members', 'private')"
+        },
+        "events_status_check": {
+          "name": "events_status_check",
+          "value": "\"events\".\"status\" in ('draft', 'published', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_idx": {
+          "name": "messages_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_idx": {
+          "name": "messages_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_created_idx": {
+          "name": "messages_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_users_id_fk": {
+          "name": "messages_sender_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messages_type_check": {
+          "name": "messages_type_check",
+          "value": "\"messages\".\"type\" in ('text', 'image', 'file', 'system')"
+        },
+        "messages_status_check": {
+          "name": "messages_status_check",
+          "value": "\"messages\".\"status\" in ('sent', 'delivered', 'read')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'job'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_remote": {
+          "name": "is_remote",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "application_url": {
+          "name": "application_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compensation": {
+          "name": "compensation",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "opportunities_owner_idx": {
+          "name": "opportunities_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunities_program_idx": {
+          "name": "opportunities_program_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunities_type_idx": {
+          "name": "opportunities_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_owner_id_users_id_fk": {
+          "name": "opportunities_owner_id_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunities_program_id_programs_id_fk": {
+          "name": "opportunities_program_id_programs_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "opportunities_type_check": {
+          "name": "opportunities_type_check",
+          "value": "\"opportunities\".\"type\" in ('scholarship', 'job', 'grant', 'volunteer', 'fellowship')"
+        },
+        "opportunities_status_check": {
+          "name": "opportunities_status_check",
+          "value": "\"opportunities\".\"status\" in ('draft', 'open', 'closed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "participants_user_idx": {
+          "name": "participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "participants_conversation_id_conversations_id_fk": {
+          "name": "participants_conversation_id_conversations_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_user_id_users_id_fk": {
+          "name": "participants_user_id_users_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "participants_pkey": {
+          "name": "participants_pkey",
+          "columns": [
+            "conversation_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "participants_role_check": {
+          "name": "participants_role_check",
+          "value": "\"participants\".\"role\" in ('member', 'moderator')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_user_id_key": {
+          "name": "profiles_user_id_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_display_name_idx": {
+          "name": "profiles_display_name_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_id": {
+          "name": "business_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "programs_owner_idx": {
+          "name": "programs_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs_business_idx": {
+          "name": "programs_business_idx",
+          "columns": [
+            {
+              "expression": "business_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs_status_idx": {
+          "name": "programs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "programs_owner_id_users_id_fk": {
+          "name": "programs_owner_id_users_id_fk",
+          "tableFrom": "programs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "programs_business_id_businesses_id_fk": {
+          "name": "programs_business_id_businesses_id_fk",
+          "tableFrom": "programs",
+          "tableTo": "businesses",
+          "columnsFrom": [
+            "business_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "programs_status_check": {
+          "name": "programs_status_check",
+          "value": "\"programs\".\"status\" in ('draft', 'published', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reports_reporter_idx": {
+          "name": "reports_reporter_idx",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_subject_idx": {
+          "name": "reports_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_status_idx": {
+          "name": "reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_reporter_id_users_id_fk": {
+          "name": "reports_reporter_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reports_subject_check": {
+          "name": "reports_subject_check",
+          "value": "\"reports\".\"subject_type\" in ('user', 'business', 'event', 'announcement', 'classified', 'message')"
+        },
+        "reports_status_check": {
+          "name": "reports_status_check",
+          "value": "\"reports\".\"status\" in ('pending', 'reviewing', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.rsvps": {
+      "name": "rsvps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "guest_count": {
+          "name": "guest_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rsvps_unique_attendee": {
+          "name": "rsvps_unique_attendee",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rsvps_status_idx": {
+          "name": "rsvps_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rsvps_event_id_events_id_fk": {
+          "name": "rsvps_event_id_events_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_user_id_users_id_fk": {
+          "name": "rsvps_user_id_users_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rsvps_status_check": {
+          "name": "rsvps_status_check",
+          "value": "\"rsvps\".\"status\" in ('pending', 'confirmed', 'waitlisted', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_id": {
+          "name": "business_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_customer_id": {
+          "name": "provider_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_subscription_id": {
+          "name": "provider_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_idx": {
+          "name": "subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_business_idx": {
+          "name": "subscriptions_business_idx",
+          "columns": [
+            {
+              "expression": "business_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_business_id_businesses_id_fk": {
+          "name": "subscriptions_business_id_businesses_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "businesses",
+          "columnsFrom": [
+            "business_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "subscriptions_plan_check": {
+          "name": "subscriptions_plan_check",
+          "value": "\"subscriptions\".\"plan\" in ('free', 'plus', 'family')"
+        },
+        "subscriptions_status_check": {
+          "name": "subscriptions_status_check",
+          "value": "\"subscriptions\".\"status\" in ('active', 'trialing', 'past_due', 'canceled', 'incomplete')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage": {
+      "name": "usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_id": {
+          "name": "business_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_scope_idx": {
+          "name": "usage_scope_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_window_idx": {
+          "name": "usage_window_idx",
+          "columns": [
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_unique_window": {
+          "name": "usage_unique_window",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "business_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_user_id_users_id_fk": {
+          "name": "usage_user_id_users_id_fk",
+          "tableFrom": "usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_business_id_businesses_id_fk": {
+          "name": "usage_business_id_businesses_id_fk",
+          "tableFrom": "usage",
+          "tableTo": "businesses",
+          "columnsFrom": [
+            "business_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "usage_scope_check": {
+          "name": "usage_scope_check",
+          "value": "\"usage\".\"scope\" in ('global', 'user', 'business')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sign_in_at": {
+          "name": "last_sign_in_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_status_idx": {
+          "name": "users_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" in ('member', 'moderator', 'admin')"
+        },
+        "users_status_check": {
+          "name": "users_status_check",
+          "value": "\"users\".\"status\" in ('active', 'inactive', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1758205075012,
+      "tag": "0000_quiet_major_mapleleaf",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "@types/connect-pg-simple": "^7.0.3",
         "@types/express-session": "^1.18.0",
         "@types/ws": "^8.5.13",
+        "drizzle-kit": "^0.31.4",
         "tsx": "^4.20.5"
       }
     },
@@ -890,6 +891,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
@@ -926,6 +934,510 @@
       "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
       "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "license": "MIT"
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.3.2",
+        "get-tsconfig": "^4.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -6629,6 +7141,22 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/drizzle-kit": {
+      "version": "0.31.4",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.4.tgz",
+      "integrity": "sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "esbuild": "^0.25.4",
+        "esbuild-register": "^3.5.0"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
+      }
+    },
     "node_modules/drizzle-orm": {
       "version": "0.36.4",
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.36.4.tgz",
@@ -7168,14 +7696,387 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
       "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
       "peerDependencies": {
         "esbuild": ">=0.12 <1"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/escalade": {
@@ -14504,6 +15405,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/speedline-core": {

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "@auth/prisma-adapter": "^2.10.0",
     "@hookform/resolvers": "^3.9.0",
     "@lhci/cli": "^0.15.1",
+    "@neondatabase/serverless": "^0.10.1",
     "@playwright/test": "^1.55.0",
     "@prisma/client": "^6.16.1",
-    "@neondatabase/serverless": "^0.10.1",
     "@stripe/react-stripe-js": "^4.0.2",
     "@stripe/stripe-js": "^7.9.0",
     "@tailwindcss/forms": "^0.5.7",
@@ -98,6 +98,7 @@
     "@types/connect-pg-simple": "^7.0.3",
     "@types/express-session": "^1.18.0",
     "@types/ws": "^8.5.13",
+    "drizzle-kit": "^0.31.4",
     "tsx": "^4.20.5"
   }
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,688 +1,826 @@
-// UiQ Community Platform - Database Schema
-// Updated to match actual database structure exactly
-// Using integration blueprints: javascript_log_in_with_replit, javascript_database
-
-import { sql } from 'drizzle-orm';
+import { sql } from "drizzle-orm";
 import {
-  index,
-  jsonb,
-  pgTable,
-  timestamp,
-  varchar,
-  text,
-  integer,
   boolean,
-  decimal,
-  pgEnum,
+  check,
+  index,
+  integer,
+  jsonb,
   numeric,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
 } from "drizzle-orm/pg-core";
 
-// Session storage table for Replit Auth (MANDATORY - do not modify)
-export const sessions = pgTable(
-  "sessions",
+export const userRoles = ["member", "moderator", "admin"] as const;
+export type UserRole = (typeof userRoles)[number];
+
+export const userStatuses = ["active", "inactive", "suspended"] as const;
+export type UserStatus = (typeof userStatuses)[number];
+
+export const businessStatuses = ["draft", "review", "published", "archived"] as const;
+export type BusinessStatus = (typeof businessStatuses)[number];
+
+export const businessPlans = ["basic", "standard", "premium"] as const;
+export type BusinessPlan = (typeof businessPlans)[number];
+
+export const reviewStatuses = ["pending", "published", "removed"] as const;
+export type ReviewStatus = (typeof reviewStatuses)[number];
+
+export const eventVisibilities = ["public", "members", "private"] as const;
+export type EventVisibility = (typeof eventVisibilities)[number];
+
+export const eventStatuses = ["draft", "published", "cancelled"] as const;
+export type EventStatus = (typeof eventStatuses)[number];
+
+export const rsvpStatuses = ["pending", "confirmed", "waitlisted", "cancelled"] as const;
+export type RsvpStatus = (typeof rsvpStatuses)[number];
+
+export const announcementTypes = ["general", "bereavement", "urgent", "celebration"] as const;
+export type AnnouncementType = (typeof announcementTypes)[number];
+
+export const announcementAudiences = ["public", "members", "admins"] as const;
+export type AnnouncementAudience = (typeof announcementAudiences)[number];
+
+export const programStatuses = ["draft", "published", "archived"] as const;
+export type ProgramStatus = (typeof programStatuses)[number];
+
+export const opportunityTypes = ["scholarship", "job", "grant", "volunteer", "fellowship"] as const;
+export type OpportunityType = (typeof opportunityTypes)[number];
+
+export const opportunityStatuses = ["draft", "open", "closed"] as const;
+export type OpportunityStatus = (typeof opportunityStatuses)[number];
+
+export const classifiedTypes = ["offer", "request"] as const;
+export type ClassifiedType = (typeof classifiedTypes)[number];
+
+export const classifiedStatuses = ["draft", "published", "archived"] as const;
+export type ClassifiedStatus = (typeof classifiedStatuses)[number];
+
+export const participantRoles = ["member", "moderator"] as const;
+export type ParticipantRole = (typeof participantRoles)[number];
+
+export const messageTypes = ["text", "image", "file", "system"] as const;
+export type MessageType = (typeof messageTypes)[number];
+
+export const messageStatuses = ["sent", "delivered", "read"] as const;
+export type MessageStatus = (typeof messageStatuses)[number];
+
+export const reportSubjects = [
+  "user",
+  "business",
+  "event",
+  "announcement",
+  "classified",
+  "message",
+] as const;
+export type ReportSubject = (typeof reportSubjects)[number];
+
+export const reportStatuses = ["pending", "reviewing", "resolved", "dismissed"] as const;
+export type ReportStatus = (typeof reportStatuses)[number];
+
+export const subscriptionStatuses = [
+  "active",
+  "trialing",
+  "past_due",
+  "canceled",
+  "incomplete",
+] as const;
+export type SubscriptionStatus = (typeof subscriptionStatuses)[number];
+
+export const subscriptionPlans = ["free", "plus", "family"] as const;
+export type SubscriptionPlan = (typeof subscriptionPlans)[number];
+
+export const usageScopes = ["global", "user", "business"] as const;
+export type UsageScope = (typeof usageScopes)[number];
+
+export const users = pgTable(
+  "users",
   {
-    sid: varchar("sid").primaryKey(),
-    sess: jsonb("sess").notNull(),
-    expire: timestamp("expire").notNull(),
+    id: uuid("id").defaultRandom().primaryKey(),
+    email: varchar("email", { length: 255 }).notNull(),
+    role: varchar("role", { length: 32 })
+      .notNull()
+      .default("member")
+      .$type<UserRole>(),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("active")
+      .$type<UserStatus>(),
+    passwordHash: varchar("password_hash", { length: 255 }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    lastSignInAt: timestamp("last_sign_in_at", { withTimezone: true }),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
   },
-  (table) => [index("IDX_session_expire").on(table.expire)],
+  (table) => ({
+    usersEmailKey: uniqueIndex("users_email_key").on(table.email),
+    usersRoleIdx: index("users_role_idx").on(table.role),
+    usersStatusIdx: index("users_status_idx").on(table.status),
+    usersRoleCheck: check(
+      "users_role_check",
+      sql`${table.role} in ('member', 'moderator', 'admin')`,
+    ),
+    usersStatusCheck: check(
+      "users_status_check",
+      sql`${table.status} in ('active', 'inactive', 'suspended')`,
+    ),
+  }),
 );
 
-// Enums - Updated to match database exactly
-export const businessPlanEnum = pgEnum("business_plan", ["Basic", "Standard", "Premium"]);
-export const businessStatusEnum = pgEnum("business_status", ["draft", "review", "published"]);
-export const membershipTierEnum = pgEnum("membership_tier", ["free", "plus", "family"]);
-export const subscriptionStatusEnum = pgEnum("subscription_status", ["active", "inactive", "trialing", "past_due", "canceled", "unpaid"]);
-export const announcementTypeEnum = pgEnum("announcement_type", ["general", "bereavement", "urgent", "celebration"]);
-export const eventVisibilityEnum = pgEnum("event_visibility", ["public", "members", "private"]);
-export const reportTypeEnum = pgEnum("report_type", ["spam", "inappropriate", "harassment", "fake", "other"]);
-export const moderationStatusEnum = pgEnum("moderation_status", ["pending", "approved", "rejected", "flagged", "removed"]);
-export const verificationType = pgEnum("verification_type", ["email", "phone", "manual"]);
-export const auditActionEnum = pgEnum("audit_action", ["create", "update", "delete", "login", "logout", "verify", "flag", "moderate", "block", "unblock"]);
-export const contentTypeEnum = pgEnum("content_type", ["business", "listing", "message", "review", "announcement", "event", "user_profile"]);
-export const opportunityTypeEnum = pgEnum("opportunity_type", ["scholarship", "job", "grant", "program", "volunteer"]);
-export const listingTypeEnum = pgEnum("listing_type", ["for_sale", "housing", "roommate", "service", "wanted"]);
-export const categoryTypeEnum = pgEnum("category_type", ["business", "event", "listing", "announcement", "cause", "program", "opportunity"]);
-export const causeStatusEnum = pgEnum("cause_status", ["draft", "active", "completed", "paused", "cancelled"]);
-export const causeTypeEnum = pgEnum("cause_type", ["fundraising", "awareness", "volunteer", "donation", "community_support"]);
-export const uploadStatusEnum = pgEnum("upload_status", ["uploading", "processing", "completed", "failed", "deleted"]);
-export const uploadTypeEnum = pgEnum("upload_type", ["image", "document", "video", "audio", "other"]);
+export const profiles = pgTable(
+  "profiles",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    displayName: varchar("display_name", { length: 160 }).notNull(),
+    pronouns: varchar("pronouns", { length: 80 }),
+    bio: text("bio"),
+    avatarUrl: varchar("avatar_url", { length: 512 }),
+    location: varchar("location", { length: 255 }),
+    websiteUrl: varchar("website_url", { length: 512 }),
+    socialLinks: jsonb("social_links").default(sql`'[]'::jsonb`).notNull(),
+    preferences: jsonb("preferences").default(sql`'{}'::jsonb`).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    profilesUserIdx: uniqueIndex("profiles_user_id_key").on(table.userId),
+    profilesDisplayNameIdx: index("profiles_display_name_idx").on(
+      table.displayName,
+    ),
+  }),
+);
 
-// Users - Updated to match database structure exactly
-export const users = pgTable("users", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  email: varchar("email").unique(),
-  first_name: varchar("first_name"),
-  last_name: varchar("last_name"),
-  profile_image_url: varchar("profile_image_url"),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-  membership_tier: varchar("membership_tier").default("basic"),
-  membership_expires_at: timestamp("membership_expires_at"),
-  is_verified: boolean("is_verified").default(false),
-  bio: text("bio"),
-  location: varchar("location"),
-  phone: varchar("phone"),
-  privacy_settings: jsonb("privacy_settings").default('{"contact": "members", "profile": "public"}'),
-  slug: varchar("slug").unique(),
-  avatar: varchar("avatar"),
-  whatsapp_link: varchar("whatsapp_link"),
-  badges: jsonb("badges").default('[]'),
-  name: varchar("name"),
-}, (table) => [
-  index("users_slug_idx").on(table.slug),
-  index("users_email_idx").on(table.email),
-]);
+export const businesses = pgTable(
+  "businesses",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    ownerId: uuid("owner_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 255 }).notNull(),
+    slug: varchar("slug", { length: 255 }).notNull(),
+    description: text("description"),
+    category: varchar("category", { length: 120 }).notNull(),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("draft")
+      .$type<BusinessStatus>(),
+    plan: varchar("plan", { length: 32 })
+      .notNull()
+      .default("basic")
+      .$type<BusinessPlan>(),
+    email: varchar("email", { length: 255 }),
+    phone: varchar("phone", { length: 32 }),
+    website: varchar("website", { length: 512 }),
+    addressLine1: varchar("address_line1", { length: 255 }),
+    addressLine2: varchar("address_line2", { length: 255 }),
+    city: varchar("city", { length: 120 }),
+    state: varchar("state", { length: 120 }),
+    postalCode: varchar("postal_code", { length: 32 }),
+    country: varchar("country", { length: 120 }),
+    latitude: numeric("latitude", { precision: 9, scale: 6 }),
+    longitude: numeric("longitude", { precision: 9, scale: 6 }),
+    tags: jsonb("tags").default(sql`'[]'::jsonb`).notNull(),
+    hours: jsonb("hours").default(sql`'{}'::jsonb`).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    businessesSlugKey: uniqueIndex("businesses_slug_key").on(table.slug),
+    businessesOwnerIdx: index("businesses_owner_idx").on(table.ownerId),
+    businessesCategoryIdx: index("businesses_category_idx").on(table.category),
+    businessesStatusIdx: index("businesses_status_idx").on(table.status),
+    businessesStatusCheck: check(
+      "businesses_status_check",
+      sql`${table.status} in ('draft', 'review', 'published', 'archived')`,
+    ),
+    businessesPlanCheck: check(
+      "businesses_plan_check",
+      sql`${table.plan} in ('basic', 'standard', 'premium')`,
+    ),
+  }),
+);
 
-// Businesses - Updated to match database structure exactly
-export const businesses = pgTable("businesses", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  owner_id: varchar("owner_id"),
-  name: varchar("name").notNull(),
-  description: text("description"),
-  category: varchar("category").notNull(),
-  subscription_tier: businessPlanEnum("subscription_tier").default("Basic"),
-  is_verified: boolean("is_verified").default(false),
-  email: varchar("email"),
-  phone: varchar("phone"),
-  website: varchar("website"),
-  address: text("address"),
-  latitude: numeric("latitude"),
-  longitude: numeric("longitude"),
-  hours: jsonb("hours"),
-  images: jsonb("images"),
-  tags: jsonb("tags"),
-  average_rating: numeric("average_rating").default("0"),
-  review_count: integer("review_count").default(0),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-  slug: varchar("slug"),
-  service_radius_km: integer("service_radius_km").default(10),
-  certifications: jsonb("certifications").default('[]'),
-  contact_methods: jsonb("contact_methods"),
-}, (table) => [
-  index("businesses_slug_idx").on(table.slug),
-  index("businesses_owner_idx").on(table.owner_id),
-  index("businesses_category_idx").on(table.category),
-]);
+export const businessReviews = pgTable(
+  "business_reviews",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    businessId: uuid("business_id")
+      .notNull()
+      .references(() => businesses.id, { onDelete: "cascade" }),
+    authorId: uuid("author_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    rating: integer("rating").notNull(),
+    title: varchar("title", { length: 255 }),
+    body: text("body"),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("pending")
+      .$type<ReviewStatus>(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
+  },
+  (table) => ({
+    businessReviewsBusinessIdx: index("business_reviews_business_idx").on(
+      table.businessId,
+    ),
+    businessReviewsAuthorIdx: index("business_reviews_author_idx").on(
+      table.authorId,
+    ),
+    businessReviewsUniqueReviewer: uniqueIndex(
+      "business_reviews_unique_reviewer",
+    ).on(table.businessId, table.authorId),
+    businessReviewsStatusCheck: check(
+      "business_reviews_status_check",
+      sql`${table.status} in ('pending', 'published', 'removed')`,
+    ),
+    businessReviewsRatingCheck: check(
+      "business_reviews_rating_check",
+      sql`${table.rating} between 1 and 5`,
+    ),
+  }),
+);
 
-// Events - Updated to match database structure exactly
-export const events = pgTable("events", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  organizer_id: varchar("organizer_id").notNull(),
-  title: varchar("title").notNull(),
-  description: text("description"),
-  category: varchar("category").notNull(),
-  start_date_time: timestamp("start_date_time").notNull(),
-  end_date_time: timestamp("end_date_time"),
-  location: varchar("location"),
-  address: text("address"),
-  latitude: numeric("latitude"),
-  longitude: numeric("longitude"),
-  max_attendees: integer("max_attendees"),
-  current_attendees: integer("current_attendees").default(0),
-  is_public: boolean("is_public").default(true),
-  requires_rsvp: boolean("requires_rsvp").default(true),
-  image_url: varchar("image_url"),
-  external_url: varchar("external_url"),
-  tags: jsonb("tags"),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-  slug: varchar("slug"),
-  price_cents: integer("price_cents").default(0),
-  rsvp_limit: integer("rsvp_limit"),
-  photos: jsonb("photos").default('[]'),
-}, (table) => [
-  index("events_slug_idx").on(table.slug),
-  index("events_organizer_idx").on(table.organizer_id),
-  index("events_start_idx").on(table.start_date_time),
-]);
+export const events = pgTable(
+  "events",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizerId: uuid("organizer_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    businessId: uuid("business_id").references(() => businesses.id, {
+      onDelete: "set null",
+    }),
+    title: varchar("title", { length: 255 }).notNull(),
+    description: text("description"),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("draft")
+      .$type<EventStatus>(),
+    visibility: varchar("visibility", { length: 32 })
+      .notNull()
+      .default("public")
+      .$type<EventVisibility>(),
+    capacity: integer("capacity"),
+    rsvpDeadline: timestamp("rsvp_deadline", { withTimezone: true }),
+    locationName: varchar("location_name", { length: 255 }),
+    address: text("address"),
+    latitude: numeric("latitude", { precision: 9, scale: 6 }),
+    longitude: numeric("longitude", { precision: 9, scale: 6 }),
+    startAt: timestamp("start_at", { withTimezone: true }).notNull(),
+    endAt: timestamp("end_at", { withTimezone: true }),
+    tags: jsonb("tags").default(sql`'[]'::jsonb`).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    eventsOrganizerIdx: index("events_organizer_idx").on(table.organizerId),
+    eventsBusinessIdx: index("events_business_idx").on(table.businessId),
+    eventsStartIdx: index("events_start_idx").on(table.startAt),
+    eventsStatusIdx: index("events_status_idx").on(table.status),
+    eventsVisibilityCheck: check(
+      "events_visibility_check",
+      sql`${table.visibility} in ('public', 'members', 'private')`,
+    ),
+    eventsStatusCheck: check(
+      "events_status_check",
+      sql`${table.status} in ('draft', 'published', 'cancelled')`,
+    ),
+  }),
+);
 
-// Event RSVPs
-export const event_rsvps = pgTable("event_rsvps", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  event_id: varchar("event_id").references(() => events.id).notNull(),
-  user_id: varchar("user_id").references(() => users.id).notNull(),
-  status: varchar("status").notNull().default("attending"),
-  created_at: timestamp("created_at").defaultNow(),
-});
+export const rsvps = pgTable(
+  "rsvps",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    eventId: uuid("event_id")
+      .notNull()
+      .references(() => events.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("pending")
+      .$type<RsvpStatus>(),
+    guestCount: integer("guest_count").notNull().default(1),
+    respondedAt: timestamp("responded_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    notes: text("notes"),
+  },
+  (table) => ({
+    rsvpsUniqueAttendee: uniqueIndex("rsvps_unique_attendee").on(
+      table.eventId,
+      table.userId,
+    ),
+    rsvpsStatusIdx: index("rsvps_status_idx").on(table.status),
+    rsvpsStatusCheck: check(
+      "rsvps_status_check",
+      sql`${table.status} in ('pending', 'confirmed', 'waitlisted', 'cancelled')`,
+    ),
+  }),
+);
 
-// Reviews
-export const reviews = pgTable("reviews", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  business_id: varchar("business_id").references(() => businesses.id).notNull(),
-  author_id: varchar("author_id").references(() => users.id).notNull(),
-  rating: integer("rating").notNull(),
-  text: text("text"),
-  photos: jsonb("photos").default('[]'),
-  status: varchar("status").default("pending"),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("reviews_business_idx").on(table.business_id),
-  index("reviews_author_idx").on(table.author_id),
-]);
+export const announcements = pgTable(
+  "announcements",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    authorId: uuid("author_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    title: varchar("title", { length: 255 }).notNull(),
+    body: text("body").notNull(),
+    type: varchar("type", { length: 32 })
+      .notNull()
+      .default("general")
+      .$type<AnnouncementType>(),
+    audience: varchar("audience", { length: 32 })
+      .notNull()
+      .default("public")
+      .$type<AnnouncementAudience>(),
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    attachments: jsonb("attachments").default(sql`'[]'::jsonb`).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    announcementsAuthorIdx: index("announcements_author_idx").on(
+      table.authorId,
+    ),
+    announcementsPublishedIdx: index("announcements_published_idx").on(
+      table.publishedAt,
+    ),
+    announcementsTypeIdx: index("announcements_type_idx").on(table.type),
+    announcementsTypeCheck: check(
+      "announcements_type_check",
+      sql`${table.type} in ('general', 'bereavement', 'urgent', 'celebration')`,
+    ),
+    announcementsAudienceCheck: check(
+      "announcements_audience_check",
+      sql`${table.audience} in ('public', 'members', 'admins')`,
+    ),
+  }),
+);
 
-// Announcements
-export const announcements = pgTable("announcements", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  type: announcementTypeEnum("type").notNull(),
-  title: varchar("title").notNull(),
-  slug: varchar("slug").unique().notNull(),
-  body: text("body").notNull(),
-  photos: jsonb("photos").default('[]'),
-  author_id: varchar("author_id").references(() => users.id).notNull(),
-  ceremony_timeline: jsonb("ceremony_timeline").default('[]'),
-  contribution_mode: varchar("contribution_mode").default("linkout"),
-  contribution_links: jsonb("contribution_links").default('[]'),
-  status: businessStatusEnum("status").default("draft"),
-  verified: boolean("verified").default(false),
-  featured: boolean("featured").default(false),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("announcements_slug_idx").on(table.slug),
-  index("announcements_type_idx").on(table.type),
-  index("announcements_author_idx").on(table.author_id),
-]);
+export const programs = pgTable(
+  "programs",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    ownerId: uuid("owner_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    businessId: uuid("business_id").references(() => businesses.id, {
+      onDelete: "set null",
+    }),
+    title: varchar("title", { length: 255 }).notNull(),
+    summary: varchar("summary", { length: 512 }),
+    description: text("description"),
+    category: varchar("category", { length: 120 }),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("draft")
+      .$type<ProgramStatus>(),
+    startAt: timestamp("start_at", { withTimezone: true }),
+    endAt: timestamp("end_at", { withTimezone: true }),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    programsOwnerIdx: index("programs_owner_idx").on(table.ownerId),
+    programsBusinessIdx: index("programs_business_idx").on(table.businessId),
+    programsStatusIdx: index("programs_status_idx").on(table.status),
+    programsStatusCheck: check(
+      "programs_status_check",
+      sql`${table.status} in ('draft', 'published', 'archived')`,
+    ),
+  }),
+);
 
-// Programs
-export const programs = pgTable("programs", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  title: varchar("title").notNull(),
-  slug: varchar("slug").unique().notNull(),
-  org: varchar("org").notNull(),
-  eligibility: text("eligibility"),
-  deadline_at: timestamp("deadline_at"),
-  apply_url: varchar("apply_url"),
-  description: text("description"),
-  tags: jsonb("tags").default('[]'),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("programs_slug_idx").on(table.slug),
-  index("programs_deadline_idx").on(table.deadline_at),
-]);
+export const opportunities = pgTable(
+  "opportunities",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    ownerId: uuid("owner_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    programId: uuid("program_id").references(() => programs.id, {
+      onDelete: "set null",
+    }),
+    title: varchar("title", { length: 255 }).notNull(),
+    description: text("description"),
+    type: varchar("type", { length: 32 })
+      .notNull()
+      .default("job")
+      .$type<OpportunityType>(),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("draft")
+      .$type<OpportunityStatus>(),
+    location: varchar("location", { length: 255 }),
+    isRemote: boolean("is_remote").notNull().default(false),
+    applicationUrl: varchar("application_url", { length: 512 }),
+    compensation: varchar("compensation", { length: 255 }),
+    postedAt: timestamp("posted_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    closesAt: timestamp("closes_at", { withTimezone: true }),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
+  },
+  (table) => ({
+    opportunitiesOwnerIdx: index("opportunities_owner_idx").on(table.ownerId),
+    opportunitiesProgramIdx: index("opportunities_program_idx").on(
+      table.programId,
+    ),
+    opportunitiesTypeIdx: index("opportunities_type_idx").on(table.type),
+    opportunitiesStatusIdx: index("opportunities_status_idx").on(table.status),
+    opportunitiesTypeCheck: check(
+      "opportunities_type_check",
+      sql`${table.type} in ('scholarship', 'job', 'grant', 'volunteer', 'fellowship')`,
+    ),
+    opportunitiesStatusCheck: check(
+      "opportunities_status_check",
+      sql`${table.status} in ('draft', 'open', 'closed')`,
+    ),
+  }),
+);
 
-// Opportunities
-export const opportunities = pgTable("opportunities", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  title: varchar("title").notNull(),
-  type: opportunityTypeEnum("type").notNull(),
-  location: varchar("location"),
-  deadline_at: timestamp("deadline_at"),
-  description: text("description").notNull(),
-  apply_url: varchar("apply_url"),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("opportunities_type_idx").on(table.type),
-  index("opportunities_deadline_idx").on(table.deadline_at),
-]);
+export const classifieds = pgTable(
+  "classifieds",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    ownerId: uuid("owner_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    title: varchar("title", { length: 255 }).notNull(),
+    description: text("description").notNull(),
+    type: varchar("type", { length: 32 })
+      .notNull()
+      .default("offer")
+      .$type<ClassifiedType>(),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("draft")
+      .$type<ClassifiedStatus>(),
+    category: varchar("category", { length: 120 }),
+    price: numeric("price", { precision: 12, scale: 2 }),
+    currency: varchar("currency", { length: 3 }).default("USD"),
+    location: varchar("location", { length: 255 }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    contactInfo: jsonb("contact_info").default(sql`'{}'::jsonb`).notNull(),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    classifiedsOwnerIdx: index("classifieds_owner_idx").on(table.ownerId),
+    classifiedsStatusIdx: index("classifieds_status_idx").on(table.status),
+    classifiedsTypeIdx: index("classifieds_type_idx").on(table.type),
+    classifiedsStatusCheck: check(
+      "classifieds_status_check",
+      sql`${table.status} in ('draft', 'published', 'archived')`,
+    ),
+    classifiedsTypeCheck: check(
+      "classifieds_type_check",
+      sql`${table.type} in ('offer', 'request')`,
+    ),
+  }),
+);
 
-// Classifieds - Updated to match database table name
-export const classifieds = pgTable("classifieds", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  type: listingTypeEnum("type").notNull(),
-  title: varchar("title").notNull(),
-  slug: varchar("slug").unique().notNull(),
-  price_cents: integer("price_cents"),
-  currency: varchar("currency").default("AUD"),
-  condition: varchar("condition"),
-  photos: jsonb("photos").default('[]'),
-  description: text("description").notNull(),
-  location: varchar("location"),
-  geo: jsonb("geo"),
-  owner_id: varchar("owner_id").references(() => users.id).notNull(),
-  status: businessStatusEnum("status").default("published"),
-  boosted_until: timestamp("boosted_until"),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("classifieds_slug_idx").on(table.slug),
-  index("classifieds_type_idx").on(table.type),
-  index("classifieds_owner_idx").on(table.owner_id),
-]);
+export const conversations = pgTable(
+  "conversations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    createdBy: uuid("created_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    topic: varchar("topic", { length: 255 }),
+    isGroup: boolean("is_group").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
+  },
+  (table) => ({
+    conversationsCreatorIdx: index("conversations_created_by_idx").on(
+      table.createdBy,
+    ),
+  }),
+);
 
-// Pages
-export const pages = pgTable("pages", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  title: varchar("title").notNull(),
-  slug: varchar("slug").unique().notNull(),
-  body: text("body").notNull(),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("pages_slug_idx").on(table.slug),
-]);
+export const participants = pgTable(
+  "participants",
+  {
+    conversationId: uuid("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: varchar("role", { length: 32 })
+      .notNull()
+      .default("member")
+      .$type<ParticipantRole>(),
+    joinedAt: timestamp("joined_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
+  },
+  (table) => ({
+    participantsPk: primaryKey({
+      name: "participants_pkey",
+      columns: [table.conversationId, table.userId],
+    }),
+    participantsUserIdx: index("participants_user_idx").on(table.userId),
+    participantsRoleCheck: check(
+      "participants_role_check",
+      sql`${table.role} in ('member', 'moderator')`,
+    ),
+  }),
+);
 
-// Service Providers
-export const service_providers = pgTable("service_providers", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  user_id: varchar("user_id").references(() => users.id).notNull(),
-  business_name: varchar("business_name"),
-  services: jsonb("services").notNull(),
-  competence_tags: jsonb("competence_tags").notNull(),
-  qualifications: jsonb("qualifications"),
-  coverage_radius: integer("coverage_radius").default(10),
-  base_location: varchar("base_location").notNull(),
-  latitude: decimal("latitude", { precision: 10, scale: 8 }),
-  longitude: decimal("longitude", { precision: 11, scale: 8 }),
-  is_verified: boolean("is_verified").default(false),
-  average_rating: decimal("average_rating", { precision: 3, scale: 2 }).default("0"),
-  review_count: integer("review_count").default(0),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-});
+export const messages = pgTable(
+  "messages",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    conversationId: uuid("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    senderId: uuid("sender_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    type: varchar("type", { length: 32 })
+      .notNull()
+      .default("text")
+      .$type<MessageType>(),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("sent")
+      .$type<MessageStatus>(),
+    body: text("body").notNull(),
+    attachments: jsonb("attachments").default(sql`'[]'::jsonb`).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    deliveredAt: timestamp("delivered_at", { withTimezone: true }),
+    readAt: timestamp("read_at", { withTimezone: true }),
+  },
+  (table) => ({
+    messagesConversationIdx: index("messages_conversation_idx").on(
+      table.conversationId,
+    ),
+    messagesSenderIdx: index("messages_sender_idx").on(table.senderId),
+    messagesCreatedIdx: index("messages_created_idx").on(table.createdAt),
+    messagesTypeCheck: check(
+      "messages_type_check",
+      sql`${table.type} in ('text', 'image', 'file', 'system')`,
+    ),
+    messagesStatusCheck: check(
+      "messages_status_check",
+      sql`${table.status} in ('sent', 'delivered', 'read')`,
+    ),
+  }),
+);
 
-// Message Threads
-export const message_threads = pgTable("message_threads", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  participant_ids: jsonb("participant_ids").notNull(),
-  business_id: varchar("business_id").references(() => businesses.id),
-  listing_id: varchar("listing_id").references(() => classifieds.id),
-  subject: varchar("subject"),
-  last_message_at: timestamp("last_message_at").defaultNow(),
-  created_at: timestamp("created_at").defaultNow(),
-});
+export const reports = pgTable(
+  "reports",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    reporterId: uuid("reporter_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    subjectType: varchar("subject_type", { length: 32 })
+      .notNull()
+      .$type<ReportSubject>(),
+    subjectId: uuid("subject_id").notNull(),
+    reason: varchar("reason", { length: 64 }).notNull(),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("pending")
+      .$type<ReportStatus>(),
+    details: text("details"),
+    resolution: text("resolution"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
+  },
+  (table) => ({
+    reportsReporterIdx: index("reports_reporter_idx").on(table.reporterId),
+    reportsSubjectIdx: index("reports_subject_idx").on(
+      table.subjectType,
+      table.subjectId,
+    ),
+    reportsStatusIdx: index("reports_status_idx").on(table.status),
+    reportsSubjectCheck: check(
+      "reports_subject_check",
+      sql`${table.subjectType} in ('user', 'business', 'event', 'announcement', 'classified', 'message')`,
+    ),
+    reportsStatusCheck: check(
+      "reports_status_check",
+      sql`${table.status} in ('pending', 'reviewing', 'resolved', 'dismissed')`,
+    ),
+  }),
+);
 
-// Messages
-export const messages = pgTable("messages", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  thread_id: varchar("thread_id").references(() => message_threads.id).notNull(),
-  sender_id: varchar("sender_id").references(() => users.id).notNull(),
-  content: text("content").notNull(),
-  attachments: jsonb("attachments"),
-  is_read: boolean("is_read").default(false),
-  created_at: timestamp("created_at").defaultNow(),
-});
+export const usage = pgTable(
+  "usage",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    scope: varchar("scope", { length: 32 })
+      .notNull()
+      .default("global")
+      .$type<UsageScope>(),
+    userId: uuid("user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    businessId: uuid("business_id").references(() => businesses.id, {
+      onDelete: "set null",
+    }),
+    feature: varchar("feature", { length: 120 }).notNull(),
+    action: varchar("action", { length: 120 }).notNull(),
+    count: integer("count").notNull().default(0),
+    windowStart: timestamp("window_start", { withTimezone: true })
+      .notNull(),
+    windowEnd: timestamp("window_end", { withTimezone: true }).notNull(),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    usageScopeIdx: index("usage_scope_idx").on(table.scope),
+    usageWindowIdx: index("usage_window_idx").on(table.windowStart),
+    usageUniqueWindow: uniqueIndex("usage_unique_window").on(
+      table.scope,
+      table.userId,
+      table.businessId,
+      table.feature,
+      table.action,
+      table.windowStart,
+    ),
+    usageScopeCheck: check(
+      "usage_scope_check",
+      sql`${table.scope} in ('global', 'user', 'business')`,
+    ),
+  }),
+);
 
-// Community Groups
-export const community_groups = pgTable("community_groups", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  name: varchar("name").notNull(),
-  description: text("description"),
-  category: varchar("category").notNull(),
-  whatsapp_invite_link: varchar("whatsapp_invite_link"),
-  admin_id: varchar("admin_id").references(() => users.id).notNull(),
-  member_count: integer("member_count").default(0),
-  is_public: boolean("is_public").default(true),
-  tags: jsonb("tags"),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-});
+export const subscriptions = pgTable(
+  "subscriptions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    businessId: uuid("business_id").references(() => businesses.id, {
+      onDelete: "set null",
+    }),
+    plan: varchar("plan", { length: 32 })
+      .notNull()
+      .default("free")
+      .$type<SubscriptionPlan>(),
+    status: varchar("status", { length: 32 })
+      .notNull()
+      .default("active")
+      .$type<SubscriptionStatus>(),
+    provider: varchar("provider", { length: 64 }).notNull(),
+    providerCustomerId: varchar("provider_customer_id", { length: 255 }),
+    providerSubscriptionId: varchar("provider_subscription_id", {
+      length: 255,
+    }),
+    trialEndsAt: timestamp("trial_ends_at", { withTimezone: true }),
+    currentPeriodStart: timestamp("current_period_start", {
+      withTimezone: true,
+    }).notNull(),
+    currentPeriodEnd: timestamp("current_period_end", { withTimezone: true })
+      .notNull(),
+    cancelAt: timestamp("cancel_at", { withTimezone: true }),
+    canceledAt: timestamp("canceled_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
+  },
+  (table) => ({
+    subscriptionsUserIdx: index("subscriptions_user_idx").on(table.userId),
+    subscriptionsBusinessIdx: index("subscriptions_business_idx").on(
+      table.businessId,
+    ),
+    subscriptionsStatusIdx: index("subscriptions_status_idx").on(
+      table.status,
+    ),
+    subscriptionsPlanCheck: check(
+      "subscriptions_plan_check",
+      sql`${table.plan} in ('free', 'plus', 'family')`,
+    ),
+    subscriptionsStatusCheck: check(
+      "subscriptions_status_check",
+      sql`${table.status} in ('active', 'trialing', 'past_due', 'canceled', 'incomplete')`,
+    ),
+  }),
+);
 
-// Reports
-export const reports = pgTable("reports", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  reporter_id: varchar("reporter_id").references(() => users.id).notNull(),
-  reported_user_id: varchar("reported_user_id").references(() => users.id),
-  reported_business_id: varchar("reported_business_id").references(() => businesses.id),
-  reported_listing_id: varchar("reported_listing_id").references(() => classifieds.id),
-  reported_message_id: varchar("reported_message_id").references(() => messages.id),
-  reported_announcement_id: varchar("reported_announcement_id").references(() => announcements.id),
-  reported_event_id: varchar("reported_event_id").references(() => events.id),
-  reported_review_id: varchar("reported_review_id").references(() => reviews.id),
-  type: reportTypeEnum("type").notNull(),
-  description: text("description").notNull(),
-  status: moderationStatusEnum("status").default("pending"),
-  moderator_id: varchar("moderator_id").references(() => users.id),
-  moderator_notes: text("moderator_notes"),
-  moderator_action: varchar("moderator_action"),
-  auto_flagged: boolean("auto_flagged").default(false),
-  flagged_keywords: jsonb("flagged_keywords").default('[]'),
-  evidence_urls: jsonb("evidence_urls").default('[]'),
-  priority: varchar("priority").default("medium"),
-  resolved_at: timestamp("resolved_at"),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("reports_status_idx").on(table.status),
-  index("reports_priority_idx").on(table.priority),
-  index("reports_auto_flagged_idx").on(table.auto_flagged),
-]);
-
-// Subscription Plans
-export const subscription_plans = pgTable("subscription_plans", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  name: varchar("name").notNull(),
-  slug: varchar("slug").unique().notNull(),
-  plan_type: varchar("plan_type").notNull(),
-  description: text("description").notNull(),
-  price_cents: integer("price_cents").notNull(),
-  billing_period: varchar("billing_period").notNull().default("monthly"),
-  currency: varchar("currency").notNull().default("AUD"),
-  features: jsonb("features").notNull().default('[]'),
-  is_popular: boolean("is_popular").default(false),
-  is_active: boolean("is_active").default(true),
-  display_order: integer("display_order").default(0),
-  button_text: varchar("button_text").default("Get Started"),
-  button_style: varchar("button_style").default("primary"),
-  max_usage: jsonb("max_usage"),
-  stripe_price_id: varchar("stripe_price_id"),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("subscription_plans_slug_idx").on(table.slug),
-  index("subscription_plans_type_idx").on(table.plan_type),
-  index("subscription_plans_active_idx").on(table.is_active),
-]);
-
-// MISSING TABLES - Adding all missing tables from database
-
-// Memberships - User membership management
-export const memberships = pgTable("memberships", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  user_id: varchar("user_id").notNull(),
-  tier: membershipTierEnum("tier").notNull(),
-  status: varchar("status").notNull().default("active"),
-  start_date: timestamp("start_date").defaultNow(),
-  end_date: timestamp("end_date"),
-  auto_renew: boolean("auto_renew").default(true),
-  stripe_subscription_id: varchar("stripe_subscription_id"),
-  granted_by: varchar("granted_by"),
-  metadata: jsonb("metadata").default('{}'),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("memberships_user_idx").on(table.user_id),
-  index("memberships_tier_idx").on(table.tier),
-  index("memberships_status_idx").on(table.status),
-]);
-
-// Business Subscriptions - Business subscription management
-export const business_subscriptions = pgTable("business_subscriptions", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  business_id: varchar("business_id").notNull(),
-  plan: businessPlanEnum("plan").notNull(),
-  status: subscriptionStatusEnum("status").notNull(),
-  start_date: timestamp("start_date").defaultNow(),
-  end_date: timestamp("end_date"),
-  auto_renew: boolean("auto_renew").default(true),
-  stripe_subscription_id: varchar("stripe_subscription_id"),
-  features: jsonb("features").default('[]'),
-  limits: jsonb("limits").default('{}'),
-  usage: jsonb("usage").default('{}'),
-  last_billing_date: timestamp("last_billing_date"),
-  next_billing_date: timestamp("next_billing_date"),
-  metadata: jsonb("metadata").default('{}'),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("business_subscriptions_business_idx").on(table.business_id),
-  index("business_subscriptions_plan_idx").on(table.plan),
-  index("business_subscriptions_status_idx").on(table.status),
-]);
-
-// Categories - Categorization system
-export const categories = pgTable("categories", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  name: varchar("name").notNull(),
-  slug: varchar("slug").notNull(),
-  type: categoryTypeEnum("type").notNull(),
-  parent_id: varchar("parent_id"),
-  description: text("description"),
-  icon: varchar("icon"),
-  color: varchar("color"),
-  sort_order: integer("sort_order").default(0),
-  is_active: boolean("is_active").default(true),
-  is_system_category: boolean("is_system_category").default(false),
-  metadata: jsonb("metadata").default('{}'),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("categories_slug_idx").on(table.slug),
-  index("categories_type_idx").on(table.type),
-  index("categories_parent_idx").on(table.parent_id),
-]);
-
-// Causes - Fundraising/cause functionality
-export const causes = pgTable("causes", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  title: varchar("title").notNull(),
-  slug: varchar("slug").notNull(),
-  type: causeTypeEnum("type").notNull(),
-  status: causeStatusEnum("status").default("draft"),
-  description: text("description").notNull(),
-  organizer: varchar("organizer").notNull(),
-  organizer_id: varchar("organizer_id"),
-  target_amount: integer("target_amount"),
-  raised_amount: integer("raised_amount").default(0),
-  currency: varchar("currency").default("AUD"),
-  start_date: timestamp("start_date"),
-  end_date: timestamp("end_date"),
-  beneficiary: varchar("beneficiary"),
-  photos: jsonb("photos").default('[]'),
-  donation_url: varchar("donation_url"),
-  update_feed: jsonb("update_feed").default('[]'),
-  tags: jsonb("tags").default('[]'),
-  featured: boolean("featured").default(false),
-  verified: boolean("verified").default(false),
-  total_supporters: integer("total_supporters").default(0),
-  visibility: eventVisibilityEnum("visibility").default("public"),
-  metadata: jsonb("metadata").default('{}'),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("causes_slug_idx").on(table.slug),
-  index("causes_type_idx").on(table.type),
-  index("causes_status_idx").on(table.status),
-  index("causes_organizer_idx").on(table.organizer_id),
-]);
-
-// Uploads - File management system
-export const uploads = pgTable("uploads", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  file_name: varchar("file_name").notNull(),
-  original_name: varchar("original_name").notNull(),
-  file_type: uploadTypeEnum("file_type").notNull(),
-  mime_type: varchar("mime_type").notNull(),
-  file_size: integer("file_size").notNull(),
-  url: varchar("url").notNull(),
-  thumbnail_url: varchar("thumbnail_url"),
-  uploader_id: varchar("uploader_id").notNull(),
-  related_type: varchar("related_type"),
-  related_id: varchar("related_id"),
-  status: uploadStatusEnum("status").default("uploading"),
-  processed_at: timestamp("processed_at"),
-  expires_at: timestamp("expires_at"),
-  is_public: boolean("is_public").default(true),
-  download_count: integer("download_count").default(0),
-  metadata: jsonb("metadata").default('{}'),
-  moderation_status: moderationStatusEnum("moderation_status").default("pending"),
-  moderated_at: timestamp("moderated_at"),
-  moderator_id: varchar("moderator_id"),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("uploads_uploader_idx").on(table.uploader_id),
-  index("uploads_type_idx").on(table.file_type),
-  index("uploads_status_idx").on(table.status),
-  index("uploads_related_idx").on(table.related_type, table.related_id),
-]);
-
-// Audit Logs - System audit trail
-export const audit_logs = pgTable("audit_logs", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  user_id: varchar("user_id"),
-  action: auditActionEnum("action").notNull(),
-  resource_type: contentTypeEnum("resource_type").notNull(),
-  resource_id: varchar("resource_id"),
-  details: jsonb("details").default('{}'),
-  ip_address: varchar("ip_address"),
-  user_agent: text("user_agent"),
-  session_id: varchar("session_id"),
-  created_at: timestamp("created_at").defaultNow(),
-}, (table) => [
-  index("audit_logs_user_idx").on(table.user_id),
-  index("audit_logs_action_idx").on(table.action),
-  index("audit_logs_resource_idx").on(table.resource_type, table.resource_id),
-  index("audit_logs_created_idx").on(table.created_at),
-]);
-
-// Stripe Integration Tables
-
-// Stripe Products
-export const stripe_products = pgTable("stripe_products", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  stripe_product_id: varchar("stripe_product_id").notNull().unique(),
-  name: varchar("name").notNull(),
-  description: text("description"),
-  type: varchar("type").notNull(),
-  tier: varchar("tier"),
-  features: jsonb("features").default('[]'),
-  is_active: boolean("is_active").default(true),
-  display_order: integer("display_order").default(0),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("stripe_products_stripe_id_idx").on(table.stripe_product_id),
-  index("stripe_products_type_idx").on(table.type),
-]);
-
-// Stripe Prices
-export const stripe_prices = pgTable("stripe_prices", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  stripe_price_id: varchar("stripe_price_id").notNull().unique(),
-  stripe_product_id: varchar("stripe_product_id").references(() => stripe_products.stripe_product_id).notNull(),
-  amount: integer("amount").notNull(),
-  currency: varchar("currency").default("aud"),
-  interval: varchar("interval"),
-  interval_count: integer("interval_count").default(1),
-  trial_period_days: integer("trial_period_days"),
-  is_active: boolean("is_active").default(true),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("stripe_prices_stripe_id_idx").on(table.stripe_price_id),
-  index("stripe_prices_product_idx").on(table.stripe_product_id),
-]);
-
-// Stripe Customers
-export const stripe_customers = pgTable("stripe_customers", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  user_id: varchar("user_id").references(() => users.id),
-  business_id: varchar("business_id").references(() => businesses.id),
-  stripe_customer_id: varchar("stripe_customer_id").notNull().unique(),
-  email: varchar("email"),
-  name: varchar("name"),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("stripe_customers_stripe_id_idx").on(table.stripe_customer_id),
-  index("stripe_customers_user_idx").on(table.user_id),
-  index("stripe_customers_business_idx").on(table.business_id),
-]);
-
-// Stripe Subscriptions
-export const stripe_subscriptions = pgTable("stripe_subscriptions", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  stripe_subscription_id: varchar("stripe_subscription_id").notNull().unique(),
-  stripe_customer_id: varchar("stripe_customer_id").references(() => stripe_customers.stripe_customer_id).notNull(),
-  stripe_price_id: varchar("stripe_price_id").references(() => stripe_prices.stripe_price_id).notNull(),
-  status: varchar("status").notNull(),
-  current_period_start: timestamp("current_period_start"),
-  current_period_end: timestamp("current_period_end"),
-  cancel_at_period_end: boolean("cancel_at_period_end").default(false),
-  canceled_at: timestamp("canceled_at"),
-  trial_start: timestamp("trial_start"),
-  trial_end: timestamp("trial_end"),
-  metadata: jsonb("metadata").default('{}'),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("stripe_subscriptions_stripe_id_idx").on(table.stripe_subscription_id),
-  index("stripe_subscriptions_customer_idx").on(table.stripe_customer_id),
-  index("stripe_subscriptions_status_idx").on(table.status),
-]);
-
-// Stripe Payments
-export const stripe_payments = pgTable("stripe_payments", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  stripe_payment_intent_id: varchar("stripe_payment_intent_id").notNull().unique(),
-  stripe_customer_id: varchar("stripe_customer_id").references(() => stripe_customers.stripe_customer_id),
-  amount: integer("amount").notNull(),
-  currency: varchar("currency").default("aud"),
-  status: varchar("status").notNull(),
-  payment_method_id: varchar("payment_method_id"),
-  subscription_id: varchar("subscription_id").references(() => stripe_subscriptions.stripe_subscription_id),
-  description: text("description"),
-  receipt_url: varchar("receipt_url"),
-  metadata: jsonb("metadata").default('{}'),
-  created_at: timestamp("created_at").defaultNow(),
-  updated_at: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  index("stripe_payments_intent_id_idx").on(table.stripe_payment_intent_id),
-  index("stripe_payments_customer_idx").on(table.stripe_customer_id),
-  index("stripe_payments_status_idx").on(table.status),
-]);
-
-// Stripe Webhook Events
-export const stripe_webhook_events = pgTable("stripe_webhook_events", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  stripe_event_id: varchar("stripe_event_id").notNull().unique(),
-  event_type: varchar("event_type").notNull(),
-  processed: boolean("processed").default(false),
-  processing_error: text("processing_error"),
-  attempts: integer("attempts").default(0),
-  event_data: jsonb("event_data").notNull(),
-  created_at: timestamp("created_at").defaultNow(),
-  processed_at: timestamp("processed_at"),
-}, (table) => [
-  index("stripe_webhook_events_stripe_id_idx").on(table.stripe_event_id),
-  index("stripe_webhook_events_type_idx").on(table.event_type),
-  index("stripe_webhook_events_processed_idx").on(table.processed),
-]);
-
-// Type exports for TypeScript
 export type User = typeof users.$inferSelect;
-export type InsertUser = typeof users.$inferInsert;
+export type NewUser = typeof users.$inferInsert;
+export type Profile = typeof profiles.$inferSelect;
+export type NewProfile = typeof profiles.$inferInsert;
 export type Business = typeof businesses.$inferSelect;
-export type InsertBusiness = typeof businesses.$inferInsert;
+export type NewBusiness = typeof businesses.$inferInsert;
+export type BusinessReview = typeof businessReviews.$inferSelect;
+export type NewBusinessReview = typeof businessReviews.$inferInsert;
 export type Event = typeof events.$inferSelect;
-export type InsertEvent = typeof events.$inferInsert;
-export type Review = typeof reviews.$inferSelect;
-export type InsertReview = typeof reviews.$inferInsert;
+export type NewEvent = typeof events.$inferInsert;
+export type Rsvp = typeof rsvps.$inferSelect;
+export type NewRsvp = typeof rsvps.$inferInsert;
 export type Announcement = typeof announcements.$inferSelect;
-export type InsertAnnouncement = typeof announcements.$inferInsert;
+export type NewAnnouncement = typeof announcements.$inferInsert;
 export type Program = typeof programs.$inferSelect;
-export type InsertProgram = typeof programs.$inferInsert;
+export type NewProgram = typeof programs.$inferInsert;
 export type Opportunity = typeof opportunities.$inferSelect;
-export type InsertOpportunity = typeof opportunities.$inferInsert;
+export type NewOpportunity = typeof opportunities.$inferInsert;
 export type Classified = typeof classifieds.$inferSelect;
-export type InsertClassified = typeof classifieds.$inferInsert;
-export type Page = typeof pages.$inferSelect;
-export type InsertPage = typeof pages.$inferInsert;
-export type ServiceProvider = typeof service_providers.$inferSelect;
-export type MessageThread = typeof message_threads.$inferSelect;
+export type NewClassified = typeof classifieds.$inferInsert;
+export type Conversation = typeof conversations.$inferSelect;
+export type NewConversation = typeof conversations.$inferInsert;
+export type Participant = typeof participants.$inferSelect;
+export type NewParticipant = typeof participants.$inferInsert;
 export type Message = typeof messages.$inferSelect;
-export type CommunityGroup = typeof community_groups.$inferSelect;
-export type Membership = typeof memberships.$inferSelect;
-export type InsertMembership = typeof memberships.$inferInsert;
-export type BusinessSubscription = typeof business_subscriptions.$inferSelect;
-export type InsertBusinessSubscription = typeof business_subscriptions.$inferInsert;
-export type Category = typeof categories.$inferSelect;
-export type InsertCategory = typeof categories.$inferInsert;
-export type Cause = typeof causes.$inferSelect;
-export type InsertCause = typeof causes.$inferInsert;
-export type Upload = typeof uploads.$inferSelect;
-export type InsertUpload = typeof uploads.$inferInsert;
-
-// Export aliases for backward compatibility with existing imports
-export const subscriptionPlans = subscription_plans;
-export const eventRsvps = event_rsvps;
-export const serviceProviders = service_providers;
-export const messageThreads = message_threads;
-export const communityGroups = community_groups;
-export const auditLogs = audit_logs;
-export const businessSubscriptions = business_subscriptions;
-export const stripeProducts = stripe_products;
-export const stripePrices = stripe_prices;
-export const stripeCustomers = stripe_customers;
-export const stripeSubscriptions = stripe_subscriptions;
-export const stripePayments = stripe_payments;
-export const stripeWebhookEvents = stripe_webhook_events;
-
-// Additional type exports with camelCase names for backward compatibility
-export type SubscriptionPlan = typeof subscription_plans.$inferSelect;
-export type InsertSubscriptionPlan = typeof subscription_plans.$inferInsert;
+export type NewMessage = typeof messages.$inferInsert;
+export type Report = typeof reports.$inferSelect;
+export type NewReport = typeof reports.$inferInsert;
+export type Usage = typeof usage.$inferSelect;
+export type NewUsage = typeof usage.$inferInsert;
+export type Subscription = typeof subscriptions.$inferSelect;
+export type NewSubscription = typeof subscriptions.$inferInsert;
+export type InsertUser = NewUser;
+export type InsertProfile = NewProfile;
+export type InsertBusiness = NewBusiness;
+export type InsertBusinessReview = NewBusinessReview;
+export type InsertEvent = NewEvent;
+export type InsertRsvp = NewRsvp;
+export type InsertAnnouncement = NewAnnouncement;
+export type InsertProgram = NewProgram;
+export type InsertOpportunity = NewOpportunity;
+export type InsertClassified = NewClassified;
+export type InsertConversation = NewConversation;
+export type InsertParticipant = NewParticipant;
+export type InsertMessage = NewMessage;
+export type InsertReport = NewReport;
+export type InsertUsage = NewUsage;
+export type InsertSubscription = NewSubscription;


### PR DESCRIPTION
## Summary
- replace the shared schema with strongly typed Drizzle models for the initial user, business, event, messaging, and moderation tables including checks and indexes
- add a Drizzle CLI configuration and install drizzle-kit so migrations can be generated from the shared schema
- generate the initial SQL migration and snapshot that materialise the new tables and constraints

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/uiq npx drizzle-kit generate`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/uiq npx drizzle-kit migrate` *(fails: no local PostgreSQL server running)*
- `npm run type-check` *(fails: existing application code expects legacy schema/types)*

------
https://chatgpt.com/codex/tasks/task_e_68cc09f3e034832baae2b549e3c60778