### PR TITLE
Add dev session helper and enforce auth on Stripe APIs

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,0 +1,96 @@
+import { cookies } from 'next/headers'
+import { eq } from 'drizzle-orm'
+import { db, users } from '@/lib/db'
+import type { UserRole } from '@shared/schema'
+
+const DEV_USER_COOKIE = 'x-dev-user-id'
+
+type UserRecord = typeof users.$inferSelect
+
+export type SessionUser = Pick<UserRecord, 'id' | 'email' | 'role' | 'status'>
+
+export class HttpError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+    this.name = 'HttpError'
+  }
+}
+
+export class UnauthorizedError extends HttpError {
+  constructor(message = 'Authentication required') {
+    super(401, message)
+    this.name = 'UnauthorizedError'
+  }
+}
+
+export class ForbiddenError extends HttpError {
+  constructor(message = 'Forbidden') {
+    super(403, message)
+    this.name = 'ForbiddenError'
+  }
+}
+
+export async function getSessionUser(): Promise<SessionUser | null> {
+  const cookieStore = await cookies()
+  const rawUserId = cookieStore.get(DEV_USER_COOKIE)?.value?.trim()
+
+  if (!rawUserId) {
+    return null
+  }
+
+  try {
+    const [user] = await db
+      .select({
+        id: users.id,
+        email: users.email,
+        role: users.role,
+        status: users.status
+      })
+      .from(users)
+      .where(eq(users.id, rawUserId))
+      .limit(1)
+
+    if (!user) {
+      return null
+    }
+
+    return user
+  } catch (error) {
+    console.error('Failed to resolve session user from cookie', error)
+    return null
+  }
+}
+
+export async function requireUser(): Promise<SessionUser> {
+  const user = await getSessionUser()
+
+  if (!user) {
+    throw new UnauthorizedError()
+  }
+
+  return user
+}
+
+export function ensureOwnerOrAdmin(
+  user: Pick<SessionUser, 'id' | 'role'>,
+  ownerId: string | null | undefined
+): void {
+  if (!ownerId) {
+    throw new ForbiddenError('Resource is missing ownership information')
+  }
+
+  if (user.role === 'admin') {
+    return
+  }
+
+  if (user.id !== ownerId) {
+    throw new ForbiddenError('You do not have permission to modify this resource')
+  }
+}
+
+export function isAdmin(user: { role: UserRole }): boolean {
+  return user.role === 'admin'
+}

--- a/src/app/api/auth/user/route.ts
+++ b/src/app/api/auth/user/route.ts
@@ -1,27 +1,27 @@
-// User authentication endpoint for Community Platform
-// Using integration blueprint: javascript_log_in_with_replit
-
 import { NextRequest, NextResponse } from 'next/server'
+import { getSessionUser } from '../../../../../server/auth'
 
 export async function GET(_request: NextRequest) {
   try {
-    // In a real implementation, this would check the session
-    // For now, return a mock response to test the auth flow
-    // This will be replaced with actual Replit Auth session checking
-    
-    const response = NextResponse.json({
-      id: "demo-user",
-      email: "demo@example.com",
-      firstName: "Demo",
-      lastName: "User",
-      profileImageUrl: null
-    })
+    const sessionUser = await getSessionUser()
 
-    return response
+    if (!sessionUser) {
+      return NextResponse.json(
+        { message: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    return NextResponse.json({
+      id: sessionUser.id,
+      email: sessionUser.email,
+      role: sessionUser.role,
+      status: sessionUser.status
+    })
   } catch (error) {
-    console.error("Auth error:", error)
+    console.error('Auth error:', error)
     return NextResponse.json(
-      { message: "Unauthorized" },
+      { message: 'Unauthorized' },
       { status: 401 }
     )
   }

--- a/src/app/api/stripe/products/initialize/route.ts
+++ b/src/app/api/stripe/products/initialize/route.ts
@@ -5,9 +5,16 @@
 
 import { NextResponse } from 'next/server'
 import { initializeStripeProducts } from '@/lib/stripe'
+import { requireUser, isAdmin, HttpError } from '../../../../../../server/auth'
 
 export async function POST() {
   try {
+    const user = await requireUser()
+
+    if (!isAdmin(user)) {
+      throw new HttpError(403, 'Admin access required')
+    }
+
     console.log('Starting Stripe products initialization...')
     await initializeStripeProducts()
     console.log('Stripe products initialization completed successfully')
@@ -17,9 +24,15 @@ export async function POST() {
       message: 'Stripe products have been initialized with real Stripe IDs'
     })
   } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status }
+      )
+    }
     console.error('Error initializing Stripe products:', error)
     return NextResponse.json(
-      { 
+      {
         error: 'Failed to initialize Stripe products',
         details: error instanceof Error ? error.message : 'Unknown error'
       },


### PR DESCRIPTION
## Summary
- add a development session helper that reads the `x-dev-user-id` cookie and exposes guards for authenticated, owner, and admin access
- update Stripe checkout and billing portal API handlers to require the new helper, enforce owner/admin checks, and surface HTTP errors consistently
- secure the Stripe product admin endpoints and the `/api/auth/user` route behind the temporary session shim for local development

## Testing
- ❌ `npm run lint` *(fails due to existing lint warnings/errors in unrelated files)*
- ❌ `npm run type-check` *(fails due to pre-existing type errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cc18eac978832bb539987134062a6d