### PR TITLE
Implement providers API and tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  moduleNameMapping: {
+  moduleNameMapper: {
     // Handle module aliases (this will be automatically configured for you based on your tsconfig.json paths)
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@shared/(.*)$': '<rootDir>/shared/$1',

--- a/server/providers.ts
+++ b/server/providers.ts
@@ -1,0 +1,285 @@
+import { randomUUID } from 'crypto'
+
+import { and, desc, eq, ilike, or, type SQL } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { db, serviceProviders, type InsertServiceProvider } from '@/lib/db'
+import { generateSlug } from '@/lib/utils'
+import type { UserRole } from '@shared/schema'
+
+const MAX_SEARCH_RESULTS = 50
+
+const baseProviderSchema = z.object({
+  name: z.string().trim().min(2).max(255),
+  description: z.string().trim().max(2000).optional(),
+  services: z.array(z.string().trim().min(1).max(120)).max(25).optional(),
+  baseLocation: z.string().trim().min(2).max(255).optional(),
+  suburb: z.string().trim().min(2).max(120).optional(),
+  state: z.string().trim().min(2).max(120).optional(),
+  phone: z.string().trim().min(3).max(32).optional(),
+  email: z.string().trim().email().max(255).optional(),
+  website: z.string().trim().url().max(512).optional(),
+  whatsapp: z.string().trim().min(5).max(64).optional(),
+  metadata: z.record(z.any()).optional(),
+})
+
+export const providerCreateSchema = baseProviderSchema
+
+export const providerUpdateSchema = baseProviderSchema
+  .partial()
+  .extend({
+    isVerified: z.boolean().optional(),
+  })
+
+export type ProviderCreateInput = z.infer<typeof providerCreateSchema>
+export type ProviderUpdateInput = z.infer<typeof providerUpdateSchema>
+
+export type ProviderListOptions = {
+  query?: string | null
+  suburb?: string | null
+  limit?: number
+  sessionUser?: { id: string; role: UserRole } | null
+}
+
+const MAX_SLUG_ATTEMPTS = 20
+
+const normaliseOptionalString = (value?: string | null) => {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (value === null) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const normaliseServices = (services?: string[]) => {
+  if (!services) {
+    return [] as string[]
+  }
+
+  const deduped = new Set<string>()
+  for (const entry of services) {
+    const trimmed = entry.trim()
+    if (trimmed.length > 0) {
+      deduped.add(trimmed)
+    }
+  }
+
+  return Array.from(deduped)
+}
+
+const normaliseMetadata = (metadata?: Record<string, unknown>) => {
+  if (!metadata) {
+    return {}
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(metadata))
+  } catch {
+    return {}
+  }
+}
+
+async function slugExists(slug: string, excludeId?: string) {
+  const existing = await db
+    .select({ id: serviceProviders.id })
+    .from(serviceProviders)
+    .where(eq(serviceProviders.slug, slug))
+    .limit(1)
+
+  if (existing.length === 0) {
+    return false
+  }
+
+  if (excludeId && existing[0].id === excludeId) {
+    return false
+  }
+
+  return true
+}
+
+export async function generateUniqueProviderSlug(name: string, excludeId?: string) {
+  const baseSlug = (() => {
+    const generated = generateSlug(name)
+    if (generated.length > 0) {
+      return generated
+    }
+    return `provider-${randomUUID().slice(0, 8)}`
+  })()
+
+  let candidate = baseSlug
+  let attempt = 0
+
+  while (attempt < MAX_SLUG_ATTEMPTS && (await slugExists(candidate, excludeId))) {
+    attempt += 1
+    candidate = `${baseSlug}-${attempt}`
+  }
+
+  if (await slugExists(candidate, excludeId)) {
+    return `${baseSlug}-${randomUUID().slice(0, 6)}`
+  }
+
+  return candidate
+}
+
+export async function listProviders(options: ProviderListOptions = {}) {
+  const { query, suburb, limit = MAX_SEARCH_RESULTS, sessionUser } = options
+  const conditions: SQL<unknown>[] = []
+
+  if (query && query.trim().length > 0) {
+    const pattern = `%${query.trim()}%`
+    // TODO: Replace with Postgres full-text search when dedicated indexes are available.
+    conditions.push(
+      or(
+        ilike(serviceProviders.name, pattern),
+        ilike(serviceProviders.description, pattern),
+        ilike(serviceProviders.baseLocation, pattern),
+      ),
+    )
+  }
+
+  if (suburb && suburb.trim().length > 0) {
+    conditions.push(ilike(serviceProviders.suburb, `%${suburb.trim()}%`))
+  }
+
+  if (!sessionUser || sessionUser.role !== 'admin') {
+    if (sessionUser) {
+      conditions.push(
+        or(
+          eq(serviceProviders.isVerified, true),
+          eq(serviceProviders.userId, sessionUser.id),
+        ),
+      )
+    } else {
+      conditions.push(eq(serviceProviders.isVerified, true))
+    }
+  }
+
+  let queryBuilder = db
+    .select()
+    .from(serviceProviders)
+    .orderBy(desc(serviceProviders.createdAt))
+    .limit(Math.max(1, Math.min(MAX_SEARCH_RESULTS, limit)))
+
+  if (conditions.length === 1) {
+    queryBuilder = queryBuilder.where(conditions[0])
+  } else if (conditions.length > 1) {
+    queryBuilder = queryBuilder.where(and(...conditions))
+  }
+
+  return queryBuilder
+}
+
+export async function getProviderById(id: string) {
+  const [provider] = await db
+    .select()
+    .from(serviceProviders)
+    .where(eq(serviceProviders.id, id))
+    .limit(1)
+
+  return provider
+}
+
+export async function createProvider(input: ProviderCreateInput, ownerId: string) {
+  const data = providerCreateSchema.parse(input)
+  const now = new Date()
+  const slug = await generateUniqueProviderSlug(data.name)
+
+  const values: InsertServiceProvider = {
+    userId: ownerId,
+    name: data.name.trim(),
+    slug,
+    description: normaliseOptionalString(data.description) ?? null,
+    services: normaliseServices(data.services),
+    baseLocation: normaliseOptionalString(data.baseLocation),
+    suburb: normaliseOptionalString(data.suburb),
+    state: normaliseOptionalString(data.state),
+    phone: normaliseOptionalString(data.phone),
+    email: normaliseOptionalString(data.email),
+    website: normaliseOptionalString(data.website),
+    whatsapp: normaliseOptionalString(data.whatsapp),
+    metadata: normaliseMetadata(data.metadata),
+    isVerified: false,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  const [provider] = await db
+    .insert(serviceProviders)
+    .values(values)
+    .returning()
+
+  return provider
+}
+
+export async function updateProvider(id: string, input: ProviderUpdateInput) {
+  const data = providerUpdateSchema.parse(input)
+  const updates: Partial<InsertServiceProvider> = {
+    updatedAt: new Date(),
+  }
+
+  if (data.name !== undefined) {
+    updates.name = data.name.trim()
+    updates.slug = await generateUniqueProviderSlug(data.name, id)
+  }
+
+  if (data.description !== undefined) {
+    updates.description = normaliseOptionalString(data.description) ?? null
+  }
+
+  if (data.services !== undefined) {
+    updates.services = normaliseServices(data.services)
+  }
+
+  if (data.baseLocation !== undefined) {
+    updates.baseLocation = normaliseOptionalString(data.baseLocation)
+  }
+
+  if (data.suburb !== undefined) {
+    updates.suburb = normaliseOptionalString(data.suburb)
+  }
+
+  if (data.state !== undefined) {
+    updates.state = normaliseOptionalString(data.state)
+  }
+
+  if (data.phone !== undefined) {
+    updates.phone = normaliseOptionalString(data.phone)
+  }
+
+  if (data.email !== undefined) {
+    updates.email = normaliseOptionalString(data.email)
+  }
+
+  if (data.website !== undefined) {
+    updates.website = normaliseOptionalString(data.website)
+  }
+
+  if (data.whatsapp !== undefined) {
+    updates.whatsapp = normaliseOptionalString(data.whatsapp)
+  }
+
+  if (data.metadata !== undefined) {
+    updates.metadata = normaliseMetadata(data.metadata)
+  }
+
+  if (data.isVerified !== undefined) {
+    updates.isVerified = data.isVerified
+  }
+
+  const [provider] = await db
+    .update(serviceProviders)
+    .set(updates)
+    .where(eq(serviceProviders.id, id))
+    .returning()
+
+  return provider
+}
+
+export async function deleteProvider(id: string) {
+  await db.delete(serviceProviders).where(eq(serviceProviders.id, id))
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -266,6 +266,49 @@ export const businessReviews = pgTable(
   }),
 );
 
+export const serviceProviders = pgTable(
+  "service_providers",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 255 }).notNull(),
+    slug: varchar("slug", { length: 255 }).notNull(),
+    description: text("description"),
+    services: jsonb("services").default(sql`'[]'::jsonb`).notNull(),
+    baseLocation: varchar("base_location", { length: 255 }),
+    suburb: varchar("suburb", { length: 120 }),
+    state: varchar("state", { length: 120 }),
+    phone: varchar("phone", { length: 32 }),
+    email: varchar("email", { length: 255 }),
+    website: varchar("website", { length: 512 }),
+    whatsapp: varchar("whatsapp", { length: 64 }),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
+    isVerified: boolean("is_verified").default(false).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    serviceProvidersSlugKey: uniqueIndex("service_providers_slug_key").on(
+      table.slug,
+    ),
+    serviceProvidersUserIdx: index("service_providers_user_idx").on(
+      table.userId,
+    ),
+    serviceProvidersNameIdx: index("service_providers_name_idx").on(
+      table.name,
+    ),
+    serviceProvidersSuburbIdx: index("service_providers_suburb_idx").on(
+      table.suburb,
+    ),
+  }),
+);
+
 export const events = pgTable(
   "events",
   {
@@ -784,6 +827,8 @@ export type Business = typeof businesses.$inferSelect;
 export type NewBusiness = typeof businesses.$inferInsert;
 export type BusinessReview = typeof businessReviews.$inferSelect;
 export type NewBusinessReview = typeof businessReviews.$inferInsert;
+export type ServiceProvider = typeof serviceProviders.$inferSelect;
+export type NewServiceProvider = typeof serviceProviders.$inferInsert;
 export type Event = typeof events.$inferSelect;
 export type NewEvent = typeof events.$inferInsert;
 export type Rsvp = typeof rsvps.$inferSelect;
@@ -812,6 +857,7 @@ export type InsertUser = NewUser;
 export type InsertProfile = NewProfile;
 export type InsertBusiness = NewBusiness;
 export type InsertBusinessReview = NewBusinessReview;
+export type InsertServiceProvider = NewServiceProvider;
 export type InsertEvent = NewEvent;
 export type InsertRsvp = NewRsvp;
 export type InsertAnnouncement = NewAnnouncement;

--- a/src/app/api/providers/[id]/route.ts
+++ b/src/app/api/providers/[id]/route.ts
@@ -1,0 +1,161 @@
+import { NextResponse } from 'next/server'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import {
+  deleteProvider,
+  getProviderById,
+  providerUpdateSchema,
+  updateProvider,
+} from '@server/providers'
+import {
+  ensureOwnerOrAdmin,
+  getSessionUser,
+  requireUser,
+  HttpError,
+} from '@server/auth'
+
+const RATE_LIMIT_ENDPOINT: Parameters<typeof checkRateLimit>[1] = 'post_provider'
+
+type RouteParams = {
+  params: { id: string }
+}
+
+const buildRateLimitResponse = (resetTime: Date) => {
+  const retryAfterSeconds = Math.max(1, Math.ceil((resetTime.getTime() - Date.now()) / 1000))
+
+  return NextResponse.json(
+    {
+      error: 'Too many modifications. Please try again later.',
+      retryAfter: resetTime.toISOString(),
+    },
+    {
+      status: 429,
+      headers: { 'Retry-After': String(retryAfterSeconds) },
+    },
+  )
+}
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  try {
+    const provider = await getProviderById(params.id)
+
+    if (!provider) {
+      return NextResponse.json({ error: 'Provider not found' }, { status: 404 })
+    }
+
+    const sessionUser = await getSessionUser()
+    const isOwner = sessionUser && sessionUser.id === provider.userId
+    const isAdmin = sessionUser?.role === 'admin'
+
+    if (!provider.isVerified && !isOwner && !isAdmin) {
+      return NextResponse.json({ error: 'Provider not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ provider })
+  } catch (error) {
+    console.error('Failed to load provider detail', error)
+    return NextResponse.json(
+      { error: 'Failed to load provider' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const user = await requireUser()
+    const provider = await getProviderById(params.id)
+
+    if (!provider) {
+      return NextResponse.json({ error: 'Provider not found' }, { status: 404 })
+    }
+
+    ensureOwnerOrAdmin(user, provider.userId)
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      return buildRateLimitResponse(rateLimit.resetTime)
+    }
+
+    const body = await request.json()
+    const parsed = providerUpdateSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    if (parsed.data.isVerified !== undefined && user.role !== 'admin') {
+      return NextResponse.json(
+        { error: 'Only administrators can verify providers' },
+        { status: 403 },
+      )
+    }
+
+    const hasUpdates = Object.values(parsed.data).some((value) => value !== undefined)
+    if (!hasUpdates) {
+      return NextResponse.json(
+        { error: 'No changes supplied' },
+        { status: 400 },
+      )
+    }
+
+    const updated = await updateProvider(params.id, parsed.data)
+
+    return NextResponse.json({ provider: updated })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: 'Invalid JSON payload' },
+        { status: 400 },
+      )
+    }
+
+    console.error('Failed to update provider', error)
+    return NextResponse.json(
+      { error: 'Failed to update provider' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  try {
+    const user = await requireUser()
+    const provider = await getProviderById(params.id)
+
+    if (!provider) {
+      return NextResponse.json({ error: 'Provider not found' }, { status: 404 })
+    }
+
+    ensureOwnerOrAdmin(user, provider.userId)
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      return buildRateLimitResponse(rateLimit.resetTime)
+    }
+
+    await deleteProvider(params.id)
+
+    return new Response(null, { status: 204 })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error('Failed to delete provider', error)
+    return NextResponse.json(
+      { error: 'Failed to delete provider' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/providers/__tests__/routes.test.ts
+++ b/src/app/api/providers/__tests__/routes.test.ts
@@ -1,0 +1,350 @@
+jest.mock('@server/providers', () => {
+  const actual = jest.requireActual('@server/providers')
+  return {
+    ...actual,
+    listProviders: jest.fn(),
+    createProvider: jest.fn(),
+    updateProvider: jest.fn(),
+    deleteProvider: jest.fn(),
+    getProviderById: jest.fn(),
+  }
+})
+
+jest.mock('@server/auth', () => {
+  const actual = jest.requireActual('@server/auth')
+  return {
+    ...actual,
+    getSessionUser: jest.fn(),
+    requireUser: jest.fn(),
+    ensureOwnerOrAdmin: jest.fn(),
+  }
+})
+
+jest.mock('@/lib/rate-limiting', () => ({
+  checkRateLimit: jest.fn(),
+}))
+
+const createRequest = (
+  url: string,
+  init?: { method?: string; body?: unknown; headers?: Record<string, string> },
+) => {
+  const serializedBody =
+    typeof init?.body === 'string' ? init.body : init?.body !== undefined ? JSON.stringify(init.body) : undefined
+  const headerStore = new Map<string, string>()
+
+  if (init?.headers) {
+    for (const [key, value] of Object.entries(init.headers)) {
+      headerStore.set(key.toLowerCase(), value)
+    }
+  }
+
+  if (serializedBody && !headerStore.has('content-type')) {
+    headerStore.set('content-type', 'application/json')
+  }
+
+  return {
+    url,
+    method: init?.method ?? 'GET',
+    headers: {
+      get(name: string) {
+        return headerStore.get(name.toLowerCase()) ?? null
+      },
+      has(name: string) {
+        return headerStore.has(name.toLowerCase())
+      },
+    },
+    async json() {
+      if (!serializedBody) {
+        throw new Error('No JSON body present')
+      }
+      return JSON.parse(serializedBody)
+    },
+    async text() {
+      return serializedBody ?? ''
+    },
+  } as unknown as Request
+}
+
+import { GET as listProvidersGet, POST as listProvidersPost } from '../route'
+import {
+  DELETE as providerDelete,
+  GET as providerGet,
+  PATCH as providerPatch,
+} from '../[id]/route'
+import {
+  createProvider,
+  deleteProvider,
+  getProviderById,
+  listProviders,
+  updateProvider,
+} from '@server/providers'
+import {
+  ensureOwnerOrAdmin,
+  getSessionUser,
+  requireUser,
+  UnauthorizedError,
+} from '@server/auth'
+import { checkRateLimit } from '@/lib/rate-limiting'
+
+describe('Providers API routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET /api/providers', () => {
+    it('returns providers matching search filters', async () => {
+      const mockSession = { id: 'admin-1', role: 'admin', email: 'a@example.com', status: 'active' }
+      ;(getSessionUser as jest.Mock).mockResolvedValue(mockSession)
+      const providers = [
+        { id: 'p1', name: 'Alpha Plumbing', userId: 'owner-1', isVerified: true },
+      ]
+      ;(listProviders as jest.Mock).mockResolvedValue(providers)
+
+      const response = await listProvidersGet(createRequest('http://localhost/api/providers?q=plumber&suburb=CBD'))
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({ providers })
+      expect(listProviders).toHaveBeenCalledWith({
+        query: 'plumber',
+        suburb: 'CBD',
+        sessionUser: mockSession,
+      })
+    })
+
+    it('rejects invalid query parameters', async () => {
+      const response = await listProvidersGet(createRequest('http://localhost/api/providers?q=a'))
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.error).toBe('Invalid query parameters')
+    })
+  })
+
+  describe('POST /api/providers', () => {
+    it('requires authentication', async () => {
+      ;(requireUser as jest.Mock).mockRejectedValue(new UnauthorizedError())
+
+      const response = await listProvidersPost(
+        createRequest('http://localhost/api/providers', {
+          method: 'POST',
+          body: { name: 'Test Provider' },
+        }),
+      )
+
+      expect(response.status).toBe(401)
+    })
+
+    it('creates a provider when payload is valid', async () => {
+      const user = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 5,
+        resetTime: new Date(Date.now() + 60_000),
+        blocked: false,
+      })
+      const providerRecord = {
+        id: 'provider-1',
+        userId: user.id,
+        name: 'Test Provider',
+        slug: 'test-provider',
+        services: [],
+        isVerified: false,
+      }
+      ;(createProvider as jest.Mock).mockResolvedValue(providerRecord)
+
+      const response = await listProvidersPost(
+        createRequest('http://localhost/api/providers', {
+          method: 'POST',
+          body: { name: 'Test Provider' },
+        }),
+      )
+
+      expect(response.status).toBe(201)
+      const payload = await response.json()
+      expect(payload).toEqual({ provider: providerRecord })
+      expect(createProvider).toHaveBeenCalledWith({ name: 'Test Provider' }, user.id)
+    })
+
+    it('enforces rate limiting', async () => {
+      const user = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      const resetTime = new Date(Date.now() + 120_000)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: false,
+        remaining: 0,
+        resetTime,
+        blocked: false,
+      })
+
+      const response = await listProvidersPost(
+        createRequest('http://localhost/api/providers', {
+          method: 'POST',
+          body: { name: 'Test Provider' },
+        }),
+      )
+
+      expect(response.status).toBe(429)
+      const payload = await response.json()
+      expect(payload.retryAfter).toBe(resetTime.toISOString())
+    })
+  })
+
+  describe('GET /api/providers/[id]', () => {
+    it('hides unverified providers from anonymous visitors', async () => {
+      ;(getProviderById as jest.Mock).mockResolvedValue({
+        id: 'provider-1',
+        userId: 'owner-1',
+        name: 'Secret Provider',
+        slug: 'secret-provider',
+        isVerified: false,
+      })
+      ;(getSessionUser as jest.Mock).mockResolvedValue(null)
+
+      const response = await providerGet(createRequest('http://localhost/api/providers/provider-1'), {
+        params: { id: 'provider-1' },
+      })
+
+      expect(response.status).toBe(404)
+    })
+
+    it('returns unverified providers to their owner', async () => {
+      ;(getProviderById as jest.Mock).mockResolvedValue({
+        id: 'provider-1',
+        userId: 'owner-1',
+        name: 'Secret Provider',
+        slug: 'secret-provider',
+        isVerified: false,
+      })
+      const session = { id: 'owner-1', role: 'member', email: 'owner@example.com', status: 'active' }
+      ;(getSessionUser as jest.Mock).mockResolvedValue(session)
+
+      const response = await providerGet(createRequest('http://localhost/api/providers/provider-1'), {
+        params: { id: 'provider-1' },
+      })
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload.provider.id).toBe('provider-1')
+    })
+  })
+
+  describe('PATCH /api/providers/[id]', () => {
+    it('prevents non-admins from toggling verification', async () => {
+      const session = { id: 'owner-1', role: 'member', email: 'owner@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(session)
+      ;(getProviderById as jest.Mock).mockResolvedValue({
+        id: 'provider-1',
+        userId: 'owner-1',
+        name: 'Provider',
+        slug: 'provider',
+        isVerified: false,
+      })
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 5,
+        resetTime: new Date(Date.now() + 60_000),
+        blocked: false,
+      })
+
+      const response = await providerPatch(
+        createRequest('http://localhost/api/providers/provider-1', {
+          method: 'PATCH',
+          body: { isVerified: true },
+        }),
+        { params: { id: 'provider-1' } },
+      )
+
+      expect(response.status).toBe(403)
+      expect(updateProvider).not.toHaveBeenCalled()
+      expect(ensureOwnerOrAdmin).toHaveBeenCalledWith(session, 'owner-1')
+    })
+
+    it('updates provider data for authorised users', async () => {
+      const session = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(session)
+      ;(getProviderById as jest.Mock).mockResolvedValue({
+        id: 'provider-1',
+        userId: 'owner-1',
+        name: 'Provider',
+        slug: 'provider',
+        isVerified: false,
+      })
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 5,
+        resetTime: new Date(Date.now() + 60_000),
+        blocked: false,
+      })
+      const updatedRecord = {
+        id: 'provider-1',
+        userId: 'owner-1',
+        name: 'Updated Provider',
+        slug: 'updated-provider',
+        isVerified: true,
+      }
+      ;(updateProvider as jest.Mock).mockResolvedValue(updatedRecord)
+
+      const response = await providerPatch(
+        createRequest('http://localhost/api/providers/provider-1', {
+          method: 'PATCH',
+          body: { name: 'Updated Provider', isVerified: true },
+        }),
+        { params: { id: 'provider-1' } },
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload.provider).toEqual(updatedRecord)
+      expect(updateProvider).toHaveBeenCalledWith('provider-1', {
+        name: 'Updated Provider',
+        isVerified: true,
+      })
+      expect(ensureOwnerOrAdmin).toHaveBeenCalledWith(session, 'owner-1')
+    })
+  })
+
+  describe('DELETE /api/providers/[id]', () => {
+    it('removes provider when authorised', async () => {
+      const session = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(session)
+      ;(getProviderById as jest.Mock).mockResolvedValue({
+        id: 'provider-1',
+        userId: 'owner-1',
+        name: 'Provider',
+        slug: 'provider',
+        isVerified: true,
+      })
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 5,
+        resetTime: new Date(Date.now() + 60_000),
+        blocked: false,
+      })
+
+      const response = await providerDelete(
+        createRequest('http://localhost/api/providers/provider-1', { method: 'DELETE' }),
+        { params: { id: 'provider-1' } },
+      )
+
+      expect(response.status).toBe(204)
+      expect(deleteProvider).toHaveBeenCalledWith('provider-1')
+      expect(ensureOwnerOrAdmin).toHaveBeenCalledWith(session, 'owner-1')
+    })
+
+    it('returns 404 when provider does not exist', async () => {
+      const session = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(session)
+      ;(getProviderById as jest.Mock).mockResolvedValue(undefined)
+
+      const response = await providerDelete(
+        createRequest('http://localhost/api/providers/provider-1', { method: 'DELETE' }),
+        { params: { id: 'provider-1' } },
+      )
+
+      expect(response.status).toBe(404)
+      expect(deleteProvider).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { createProvider, listProviders, providerCreateSchema } from '@server/providers'
+import { getSessionUser, requireUser, HttpError } from '@server/auth'
+
+const querySchema = z.object({
+  q: z.string().trim().min(2).max(120).optional(),
+  suburb: z.string().trim().min(2).max(120).optional(),
+})
+
+const RATE_LIMIT_ENDPOINT: Parameters<typeof checkRateLimit>[1] = 'post_provider'
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const query = searchParams.get('q')?.trim()
+    const suburb = searchParams.get('suburb')?.trim()
+
+    const parsed = querySchema.safeParse({
+      q: query && query.length > 0 ? query : undefined,
+      suburb: suburb && suburb.length > 0 ? suburb : undefined,
+    })
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid query parameters',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const sessionUser = await getSessionUser()
+    const providers = await listProviders({
+      query: parsed.data.q,
+      suburb: parsed.data.suburb,
+      sessionUser,
+    })
+
+    return NextResponse.json({ providers })
+  } catch (error) {
+    console.error('Failed to load providers directory', error)
+    return NextResponse.json(
+      { error: 'Failed to load providers' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const user = await requireUser()
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000),
+      )
+
+      return NextResponse.json(
+        {
+          error: 'Too many provider submissions. Please try again later.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(retryAfterSeconds) },
+        },
+      )
+    }
+
+    const body = await request.json()
+    const parsed = providerCreateSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const provider = await createProvider(parsed.data, user.id)
+
+    return NextResponse.json({ provider }, { status: 201 })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: 'Invalid JSON payload' },
+        { status: 400 },
+      )
+    }
+
+    console.error('Failed to create provider', error)
+    return NextResponse.json(
+      { error: 'Failed to create provider' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/lib/rate-limiting.ts
+++ b/src/lib/rate-limiting.ts
@@ -30,6 +30,7 @@ export const RATE_LIMIT_CONFIGS = {
   
   // Content creation
   post_business: { windowMs: 60 * 60 * 1000, maxRequests: 5 }, // 5 business posts per hour
+  post_provider: { windowMs: 60 * 60 * 1000, maxRequests: 8 }, // 8 provider writes per hour
   post_listing: { windowMs: 60 * 60 * 1000, maxRequests: 10 }, // 10 listings per hour
   post_message: { windowMs: 60 * 1000, maxRequests: 20 }, // 20 messages per minute
   post_review: { windowMs: 60 * 60 * 1000, maxRequests: 5 }, // 5 reviews per hour


### PR DESCRIPTION
## Summary
- add the `service_providers` table and related types to the shared schema
- implement provider CRUD/search helpers with RBAC-aware filtering and slug management
- expose `/api/providers` and `/api/providers/[id]` endpoints with validation, rate limiting and guards
- extend rate limiting config, improve Jest setup polyfills, and add comprehensive route tests

## Testing
- `npm test -- src/app/api/providers/__tests__/routes.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68cc1e3fd340832bbb328e8b4756eb1b