### PR TITLE
Implement events API endpoints and RSVP schema

### DIFF
--- a/drizzle/0001_add_event_category.sql
+++ b/drizzle/0001_add_event_category.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "events" ADD COLUMN "category" varchar(120) NOT NULL DEFAULT 'general';
+CREATE INDEX IF NOT EXISTS "events_category_idx" ON "events" ("category");
+ALTER TABLE "events" ALTER COLUMN "category" DROP DEFAULT;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -865,6 +865,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "category": {
+          "name": "category",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
         "description": {
           "name": "description",
           "type": "text",
@@ -991,6 +997,21 @@
           "columns": [
             {
               "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_category_idx": {
+          "name": "events_category_idx",
+          "columns": [
+            {
+              "expression": "category",
               "isExpression": false,
               "asc": true,
               "nulls": "last"

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1758205075012,
       "tag": "0000_quiet_major_mapleleaf",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1758205076012,
+      "tag": "0001_add_event_category",
+      "breakpoints": false
     }
   ]
 }

--- a/server/events.ts
+++ b/server/events.ts
@@ -1,0 +1,372 @@
+import { and, asc, eq, or, type SQL } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { db, events, type InsertEvent } from '@/lib/db'
+import {
+  eventStatuses,
+  eventVisibilities,
+  type Event,
+  type UserRole,
+} from '@shared/schema'
+
+import { HttpError } from './auth'
+
+const isoDateTimeWithOffset = z.string().datetime({ offset: true })
+const nonEmptyTrimmedString = (min: number, max: number) =>
+  z.string().trim().min(min).max(max)
+
+const coordinateSchema = {
+  latitude: z.number().min(-90).max(90),
+  longitude: z.number().min(-180).max(180),
+}
+
+const tagsSchema = z.array(nonEmptyTrimmedString(1, 50)).max(25)
+
+const createBaseSchema = z.object({
+  title: nonEmptyTrimmedString(3, 255),
+  category: nonEmptyTrimmedString(2, 120),
+  description: nonEmptyTrimmedString(10, 5000),
+  visibility: z.enum(eventVisibilities).optional(),
+  status: z.enum(eventStatuses).optional(),
+  capacity: z.number().int().min(1).max(100_000).optional(),
+  rsvpDeadline: isoDateTimeWithOffset.optional(),
+  locationName: nonEmptyTrimmedString(2, 255).optional(),
+  address: nonEmptyTrimmedString(5, 2000).optional(),
+  latitude: coordinateSchema.latitude.optional(),
+  longitude: coordinateSchema.longitude.optional(),
+  tags: tagsSchema.optional(),
+  businessId: z.string().uuid().optional(),
+})
+
+export const eventCreateSchema = createBaseSchema
+  .extend({
+    startAt: isoDateTimeWithOffset,
+    endAt: isoDateTimeWithOffset.optional(),
+  })
+  .superRefine((value, ctx) => {
+    const start = new Date(value.startAt)
+    const end = value.endAt ? new Date(value.endAt) : null
+
+    if (end && end <= start) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['endAt'],
+        message: 'Event end time must be after the start time',
+      })
+    }
+
+    if (value.rsvpDeadline) {
+      const deadline = new Date(value.rsvpDeadline)
+      if (deadline > start) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['rsvpDeadline'],
+          message: 'RSVP deadline must be before the event start time',
+        })
+      }
+    }
+  })
+
+const nullableStringField = (schema: z.ZodString) => schema.optional().nullable()
+
+export const eventUpdateSchema = createBaseSchema
+  .partial()
+  .extend({
+    startAt: isoDateTimeWithOffset.optional(),
+    endAt: isoDateTimeWithOffset.optional().nullable(),
+    rsvpDeadline: isoDateTimeWithOffset.optional().nullable(),
+    capacity: z.number().int().min(1).max(100_000).optional().nullable(),
+    locationName: nullableStringField(nonEmptyTrimmedString(2, 255)),
+    address: nullableStringField(nonEmptyTrimmedString(5, 2000)),
+    latitude: coordinateSchema.latitude.optional().nullable(),
+    longitude: coordinateSchema.longitude.optional().nullable(),
+    businessId: z.string().uuid().optional().nullable(),
+    tags: tagsSchema.optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one field must be provided to update an event',
+  })
+
+export type EventCreateInput = z.infer<typeof eventCreateSchema>
+export type EventUpdateInput = z.infer<typeof eventUpdateSchema>
+
+export type EventListOptions = {
+  category?: string | null
+  limit?: number
+  sessionUser?: { id: string; role: UserRole } | null
+}
+
+const normaliseOptionalString = (value?: string | null) => {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (value === null) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const normaliseTags = (value?: string[]) => {
+  if (!value) {
+    return [] as string[]
+  }
+
+  const deduped = new Set<string>()
+  for (const entry of value) {
+    const trimmed = entry.trim()
+    if (trimmed.length > 0) {
+      deduped.add(trimmed)
+    }
+  }
+
+  return Array.from(deduped)
+}
+
+const toUtcDate = (value: string) => {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    throw new HttpError(400, 'Invalid date value received')
+  }
+
+  return new Date(date.toISOString())
+}
+
+const toNumericString = (value?: number | null) => {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (value === null) {
+    return null
+  }
+
+  return value.toString()
+}
+
+export async function listEvents(options: EventListOptions = {}) {
+  const { category, limit = 100, sessionUser } = options
+  const conditions: SQL[] = []
+
+  if (category && category.trim().length > 0) {
+    conditions.push(eq(events.category, category.trim()))
+  }
+
+  if (!sessionUser || sessionUser.role !== 'admin') {
+    if (sessionUser) {
+      conditions.push(
+        or(eq(events.organizerId, sessionUser.id), eq(events.status, 'published')),
+      )
+
+      conditions.push(
+        or(
+          eq(events.organizerId, sessionUser.id),
+          eq(events.visibility, 'public'),
+          eq(events.visibility, 'members'),
+        ),
+      )
+    } else {
+      conditions.push(eq(events.status, 'published'))
+      conditions.push(eq(events.visibility, 'public'))
+    }
+  }
+
+  let query = db
+    .select()
+    .from(events)
+    .orderBy(asc(events.startAt))
+    .limit(Math.max(1, Math.min(500, limit)))
+
+  if (conditions.length === 1) {
+    query = query.where(conditions[0])
+  } else if (conditions.length > 1) {
+    query = query.where(and(...conditions))
+  }
+
+  return query
+}
+
+export async function getEventById(id: string) {
+  const [event] = await db
+    .select()
+    .from(events)
+    .where(eq(events.id, id))
+    .limit(1)
+
+  return event
+}
+
+export async function createEvent(input: EventCreateInput, organizerId: string) {
+  const now = new Date()
+  const startAt = toUtcDate(input.startAt)
+  const endAt = input.endAt ? toUtcDate(input.endAt) : null
+
+  if (endAt && endAt <= startAt) {
+    throw new HttpError(400, 'Event end time must be after the start time')
+  }
+
+  const rsvpDeadline = input.rsvpDeadline ? toUtcDate(input.rsvpDeadline) : null
+
+  if (rsvpDeadline && rsvpDeadline > startAt) {
+    throw new HttpError(400, 'RSVP deadline must be before the event start time')
+  }
+
+  const values: InsertEvent = {
+    organizerId,
+    businessId: input.businessId ?? null,
+    title: input.title.trim(),
+    category: input.category.trim(),
+    description: input.description.trim(),
+    status: input.status ?? 'draft',
+    visibility: input.visibility ?? 'public',
+    capacity: input.capacity ?? null,
+    rsvpDeadline,
+    locationName: normaliseOptionalString(input.locationName) ?? null,
+    address: normaliseOptionalString(input.address) ?? null,
+    latitude: toNumericString(input.latitude) ?? null,
+    longitude: toNumericString(input.longitude) ?? null,
+    startAt,
+    endAt,
+    tags: normaliseTags(input.tags),
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  const [event] = await db
+    .insert(events)
+    .values(values)
+    .returning()
+
+  return event
+}
+
+export async function updateEvent(event: Event, input: EventUpdateInput) {
+  const updates: Partial<InsertEvent> = {
+    updatedAt: new Date(),
+  }
+
+  if (input.title !== undefined) {
+    updates.title = input.title.trim()
+  }
+
+  if (input.category !== undefined) {
+    updates.category = input.category.trim()
+  }
+
+  if (input.description !== undefined) {
+    updates.description = input.description.trim()
+  }
+
+  if (input.status !== undefined) {
+    updates.status = input.status
+  }
+
+  if (input.visibility !== undefined) {
+    updates.visibility = input.visibility
+  }
+
+  if (input.capacity !== undefined) {
+    updates.capacity = input.capacity ?? null
+  }
+
+  let nextStart = event.startAt
+  if (input.startAt !== undefined) {
+    nextStart = toUtcDate(input.startAt)
+    updates.startAt = nextStart
+  }
+
+  let nextEnd = event.endAt
+  if (input.endAt !== undefined) {
+    if (input.endAt === null) {
+      nextEnd = null
+      updates.endAt = null
+    } else {
+      nextEnd = toUtcDate(input.endAt)
+      updates.endAt = nextEnd
+    }
+  }
+
+  if (nextEnd && nextEnd <= nextStart) {
+    throw new HttpError(400, 'Event end time must be after the start time')
+  }
+
+  if (input.rsvpDeadline !== undefined) {
+    if (input.rsvpDeadline === null) {
+      updates.rsvpDeadline = null
+    } else {
+      const deadline = toUtcDate(input.rsvpDeadline)
+      if (deadline > nextStart) {
+        throw new HttpError(400, 'RSVP deadline must be before the event start time')
+      }
+      updates.rsvpDeadline = deadline
+    }
+  } else if (updates.startAt && event.rsvpDeadline && event.rsvpDeadline > nextStart) {
+    throw new HttpError(400, 'RSVP deadline must be before the event start time')
+  }
+
+  if (input.locationName !== undefined) {
+    updates.locationName = normaliseOptionalString(input.locationName) ?? null
+  }
+
+  if (input.address !== undefined) {
+    updates.address = normaliseOptionalString(input.address) ?? null
+  }
+
+  if (input.latitude !== undefined) {
+    updates.latitude = toNumericString(input.latitude) ?? null
+  }
+
+  if (input.longitude !== undefined) {
+    updates.longitude = toNumericString(input.longitude) ?? null
+  }
+
+  if (input.tags !== undefined) {
+    updates.tags = normaliseTags(input.tags)
+  }
+
+  if (input.businessId !== undefined) {
+    updates.businessId = input.businessId ?? null
+  }
+
+  const [updated] = await db
+    .update(events)
+    .set(updates)
+    .where(eq(events.id, event.id))
+    .returning()
+
+  return updated
+}
+
+export async function deleteEvent(id: string) {
+  await db.delete(events).where(eq(events.id, id))
+}
+
+export const serializeEvent = (event: Event) => {
+  const tags = Array.isArray(event.tags)
+    ? event.tags.filter((entry): entry is string => typeof entry === 'string')
+    : []
+
+  return {
+    id: event.id,
+    organizerId: event.organizerId,
+    businessId: event.businessId,
+    title: event.title,
+    category: event.category,
+    description: event.description,
+    status: event.status,
+    visibility: event.visibility,
+    capacity: event.capacity,
+    rsvpDeadline: event.rsvpDeadline ? event.rsvpDeadline.toISOString() : null,
+    locationName: event.locationName,
+    address: event.address,
+    latitude: event.latitude,
+    longitude: event.longitude,
+    startAt: event.startAt.toISOString(),
+    endAt: event.endAt ? event.endAt.toISOString() : null,
+    tags,
+    createdAt: event.createdAt.toISOString(),
+    updatedAt: event.updatedAt.toISOString(),
+  }
+}

--- a/shared/models/rsvp.ts
+++ b/shared/models/rsvp.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+
+import { rsvpStatuses } from '../schema'
+
+const isoDateTimeWithOffset = z.string().datetime({ offset: true })
+
+export const rsvpSchema = z.object({
+  id: z.string().uuid(),
+  eventId: z.string().uuid(),
+  userId: z.string().uuid(),
+  status: z.enum(rsvpStatuses),
+  guestCount: z.number().int().min(1),
+  respondedAt: isoDateTimeWithOffset,
+  notes: z.string().trim().min(1).max(2000).optional().nullable(),
+})
+
+export const rsvpCreateSchema = z.object({
+  eventId: z.string().uuid(),
+  status: z.enum(rsvpStatuses).optional(),
+  guestCount: z.number().int().min(1).max(20).default(1),
+  notes: z.string().trim().min(1).max(2000).optional(),
+})
+
+export const rsvpUpdateSchema = z
+  .object({
+    status: z.enum(rsvpStatuses).optional(),
+    guestCount: z.number().int().min(1).max(20).optional(),
+    notes: z.string().trim().min(1).max(2000).optional().nullable(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided when updating an RSVP',
+  })
+
+export type RsvpModel = z.infer<typeof rsvpSchema>
+export type CreateRsvpInput = z.infer<typeof rsvpCreateSchema>
+export type UpdateRsvpInput = z.infer<typeof rsvpUpdateSchema>

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -320,6 +320,7 @@ export const events = pgTable(
       onDelete: "set null",
     }),
     title: varchar("title", { length: 255 }).notNull(),
+    category: varchar("category", { length: 120 }).notNull(),
     description: text("description"),
     status: varchar("status", { length: 32 })
       .notNull()
@@ -349,6 +350,7 @@ export const events = pgTable(
     eventsOrganizerIdx: index("events_organizer_idx").on(table.organizerId),
     eventsBusinessIdx: index("events_business_idx").on(table.businessId),
     eventsStartIdx: index("events_start_idx").on(table.startAt),
+    eventsCategoryIdx: index("events_category_idx").on(table.category),
     eventsStatusIdx: index("events_status_idx").on(table.status),
     eventsVisibilityCheck: check(
       "events_visibility_check",

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,0 +1,193 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import {
+  HttpError,
+  ensureOwnerOrAdmin,
+  getSessionUser,
+  requireUser,
+} from '@server/auth'
+import {
+  deleteEvent,
+  eventUpdateSchema,
+  getEventById,
+  serializeEvent,
+  updateEvent,
+} from '@server/events'
+
+const idSchema = z.string().uuid()
+const RATE_LIMIT_ENDPOINT: Parameters<typeof checkRateLimit>[1] = 'post_event'
+
+type RouteContext = {
+  params: { id: string }
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const idResult = idSchema.safeParse(context.params.id)
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid event id' }, { status: 400 })
+    }
+
+    const sessionUser = await getSessionUser()
+    const event = await getEventById(idResult.data)
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const isAdmin = sessionUser?.role === 'admin'
+    const isOwner = sessionUser?.id === event.organizerId
+
+    if (!isAdmin && !isOwner) {
+      if (event.status !== 'published') {
+        return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+      }
+
+      if (event.visibility === 'private') {
+        return NextResponse.json(
+          { error: 'You do not have permission to view this event' },
+          { status: sessionUser ? 403 : 404 },
+        )
+      }
+
+      if (event.visibility === 'members' && !sessionUser) {
+        return NextResponse.json(
+          { error: 'Authentication required to view this event' },
+          { status: 401 },
+        )
+      }
+    }
+
+    return NextResponse.json({ event: serializeEvent(event) })
+  } catch (error) {
+    console.error('Failed to load event', error)
+    return NextResponse.json(
+      { error: 'Failed to load event' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const idResult = idSchema.safeParse(context.params.id)
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid event id' }, { status: 400 })
+    }
+
+    const user = await requireUser()
+    const event = await getEventById(idResult.data)
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    ensureOwnerOrAdmin(user, event.organizerId)
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000),
+      )
+
+      return NextResponse.json(
+        {
+          error: 'Too many event updates. Please try again later.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(retryAfterSeconds) },
+        },
+      )
+    }
+
+    const body = await request.json()
+    const parsed = eventUpdateSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const updated = await updateEvent(event, parsed.data)
+
+    return NextResponse.json({ event: serializeEvent(updated) })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: 'Invalid JSON payload' },
+        { status: 400 },
+      )
+    }
+
+    console.error('Failed to update event', error)
+    return NextResponse.json(
+      { error: 'Failed to update event' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  try {
+    const idResult = idSchema.safeParse(context.params.id)
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid event id' }, { status: 400 })
+    }
+
+    const user = await requireUser()
+    const event = await getEventById(idResult.data)
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    ensureOwnerOrAdmin(user, event.organizerId)
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000),
+      )
+
+      return NextResponse.json(
+        {
+          error: 'Too many event updates. Please try again later.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(retryAfterSeconds) },
+        },
+      )
+    }
+
+    await deleteEvent(event.id)
+
+    return new NextResponse(null, { status: 204 })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error('Failed to delete event', error)
+    return NextResponse.json(
+      { error: 'Failed to delete event' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/events/__tests__/routes.test.ts
+++ b/src/app/api/events/__tests__/routes.test.ts
@@ -1,0 +1,339 @@
+jest.mock('@server/events', () => {
+  const actual = jest.requireActual('@server/events')
+  return {
+    ...actual,
+    listEvents: jest.fn(),
+    createEvent: jest.fn(),
+    getEventById: jest.fn(),
+    updateEvent: jest.fn(),
+    deleteEvent: jest.fn(),
+  }
+})
+
+jest.mock('@server/auth', () => {
+  const actual = jest.requireActual('@server/auth')
+  return {
+    ...actual,
+    getSessionUser: jest.fn(),
+    requireUser: jest.fn(),
+    ensureOwnerOrAdmin: jest.fn(),
+  }
+})
+
+jest.mock('@/lib/rate-limiting', () => ({
+  checkRateLimit: jest.fn(),
+}))
+
+const createRequest = (
+  url: string,
+  init?: { method?: string; body?: unknown; headers?: Record<string, string> },
+) => {
+  const serializedBody =
+    typeof init?.body === 'string' ? init.body : init?.body !== undefined ? JSON.stringify(init.body) : undefined
+  const headerStore = new Map<string, string>()
+
+  if (init?.headers) {
+    for (const [key, value] of Object.entries(init.headers)) {
+      headerStore.set(key.toLowerCase(), value)
+    }
+  }
+
+  if (serializedBody && !headerStore.has('content-type')) {
+    headerStore.set('content-type', 'application/json')
+  }
+
+  return {
+    url,
+    method: init?.method ?? 'GET',
+    headers: {
+      get(name: string) {
+        return headerStore.get(name.toLowerCase()) ?? null
+      },
+      has(name: string) {
+        return headerStore.has(name.toLowerCase())
+      },
+    },
+    async json() {
+      if (!serializedBody) {
+        throw new Error('No JSON body present')
+      }
+      return JSON.parse(serializedBody)
+    },
+    async text() {
+      return serializedBody ?? ''
+    },
+  } as unknown as Request
+}
+
+import { GET as listEventsGet, POST as createEventPost } from '../route'
+import {
+  DELETE as deleteEventRoute,
+  GET as getEventRoute,
+  PATCH as updateEventRoute,
+} from '../[id]/route'
+import {
+  createEvent,
+  deleteEvent,
+  getEventById,
+  listEvents,
+  updateEvent,
+} from '@server/events'
+import {
+  ensureOwnerOrAdmin,
+  getSessionUser,
+  requireUser,
+  UnauthorizedError,
+} from '@server/auth'
+import { checkRateLimit } from '@/lib/rate-limiting'
+
+const baseEvent = {
+  id: '00000000-0000-0000-0000-000000000001',
+  organizerId: '00000000-0000-0000-0000-000000000010',
+  businessId: null,
+  title: 'Community Gathering',
+  category: 'community',
+  description: 'An extended description of the community gathering event.',
+  status: 'published',
+  visibility: 'public',
+  capacity: 120,
+  rsvpDeadline: new Date('2024-08-10T10:00:00Z'),
+  locationName: 'Community Hall',
+  address: '123 Main Street, Brisbane',
+  latitude: '12.345678',
+  longitude: '123.456789',
+  startAt: new Date('2024-08-15T18:00:00Z'),
+  endAt: new Date('2024-08-15T21:00:00Z'),
+  tags: ['community', 'meetup'],
+  createdAt: new Date('2024-07-01T00:00:00Z'),
+  updatedAt: new Date('2024-07-05T00:00:00Z'),
+} as const
+
+describe('Events API routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET /api/events', () => {
+    it('returns events filtered by category', async () => {
+      const sessionUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' }
+      ;(getSessionUser as jest.Mock).mockResolvedValue(sessionUser)
+      ;(listEvents as jest.Mock).mockResolvedValue([baseEvent])
+
+      const response = await listEventsGet(createRequest('http://localhost/api/events?category=community&limit=10'))
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload.events).toHaveLength(1)
+      expect(payload.events[0]).toEqual(
+        expect.objectContaining({
+          id: baseEvent.id,
+          category: baseEvent.category,
+          startAt: baseEvent.startAt.toISOString(),
+        }),
+      )
+      expect(listEvents).toHaveBeenCalledWith({
+        category: 'community',
+        limit: 10,
+        sessionUser,
+      })
+    })
+
+    it('rejects invalid filters', async () => {
+      const response = await listEventsGet(createRequest('http://localhost/api/events?category=c'))
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.error).toBe('Invalid query parameters')
+    })
+  })
+
+  describe('POST /api/events', () => {
+    it('requires authentication', async () => {
+      ;(requireUser as jest.Mock).mockRejectedValue(new UnauthorizedError())
+
+      const response = await createEventPost(
+        createRequest('http://localhost/api/events', {
+          method: 'POST',
+          body: {},
+        }),
+      )
+
+      expect(response.status).toBe(401)
+    })
+
+    it('enforces rate limiting', async () => {
+      const user = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      const resetTime = new Date('2024-07-06T10:00:00Z')
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: false,
+        remaining: 0,
+        resetTime,
+        blocked: false,
+      })
+
+      const response = await createEventPost(
+        createRequest('http://localhost/api/events', {
+          method: 'POST',
+          body: {
+            title: 'Community Gathering',
+            category: 'community',
+            description: 'An extended description of the community gathering event.',
+            startAt: '2024-08-15T18:00:00Z',
+            endAt: '2024-08-15T21:00:00Z',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(429)
+      const payload = await response.json()
+      expect(payload.retryAfter).toBe(resetTime.toISOString())
+    })
+
+    it('creates an event when payload is valid', async () => {
+      const user = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 5,
+        resetTime: new Date('2024-07-06T10:00:00Z'),
+        blocked: false,
+      })
+      ;(createEvent as jest.Mock).mockResolvedValue(baseEvent)
+
+      const response = await createEventPost(
+        createRequest('http://localhost/api/events', {
+          method: 'POST',
+          body: {
+            title: 'Community Gathering',
+            category: 'community',
+            description: 'An extended description of the community gathering event.',
+            startAt: '2024-08-15T18:00:00Z',
+            endAt: '2024-08-15T21:00:00Z',
+            visibility: 'public',
+            status: 'published',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(201)
+      const payload = await response.json()
+      expect(payload.event.title).toBe(baseEvent.title)
+      expect(payload.event.startAt).toBe(baseEvent.startAt.toISOString())
+      expect(createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Community Gathering',
+          category: 'community',
+        }),
+        user.id,
+      )
+    })
+  })
+
+  describe('GET /api/events/[id]', () => {
+    it('returns a published public event to anonymous visitors', async () => {
+      ;(getSessionUser as jest.Mock).mockResolvedValue(null)
+      ;(getEventById as jest.Mock).mockResolvedValue(baseEvent)
+
+      const response = await getEventRoute(
+        createRequest('http://localhost/api/events/00000000-0000-0000-0000-000000000001'),
+        { params: { id: baseEvent.id } },
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload.event.id).toBe(baseEvent.id)
+      expect(payload.event.visibility).toBe('public')
+    })
+
+    it('hides private events from unauthorised users', async () => {
+      ;(getSessionUser as jest.Mock).mockResolvedValue(null)
+      ;(getEventById as jest.Mock).mockResolvedValue({
+        ...baseEvent,
+        status: 'published',
+        visibility: 'private',
+      })
+
+      const response = await getEventRoute(
+        createRequest('http://localhost/api/events/00000000-0000-0000-0000-000000000001'),
+        { params: { id: baseEvent.id } },
+      )
+
+      expect(response.status).toBe(404)
+    })
+  })
+
+  describe('PATCH /api/events/[id]', () => {
+    it('updates an event when authorised', async () => {
+      const user = { id: baseEvent.organizerId, role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      ;(getEventById as jest.Mock).mockResolvedValue(baseEvent)
+      ;(ensureOwnerOrAdmin as jest.Mock).mockImplementation(() => {})
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 3,
+        resetTime: new Date('2024-07-06T10:00:00Z'),
+        blocked: false,
+      })
+      const updated = {
+        ...baseEvent,
+        title: 'Updated Community Gathering',
+        updatedAt: new Date('2024-07-06T00:00:00Z'),
+      }
+      ;(updateEvent as jest.Mock).mockResolvedValue(updated)
+
+      const response = await updateEventRoute(
+        createRequest('http://localhost/api/events/00000000-0000-0000-0000-000000000001', {
+          method: 'PATCH',
+          body: { title: 'Updated Community Gathering' },
+        }),
+        { params: { id: baseEvent.id } },
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload.event.title).toBe('Updated Community Gathering')
+      expect(updateEvent).toHaveBeenCalledWith(baseEvent, { title: 'Updated Community Gathering' })
+    })
+  })
+
+  describe('DELETE /api/events/[id]', () => {
+    it('deletes an event when authorised', async () => {
+      const user = { id: baseEvent.organizerId, role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      ;(getEventById as jest.Mock).mockResolvedValue(baseEvent)
+      ;(ensureOwnerOrAdmin as jest.Mock).mockImplementation(() => {})
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 2,
+        resetTime: new Date('2024-07-06T10:00:00Z'),
+        blocked: false,
+      })
+
+        const response = await deleteEventRoute(
+          createRequest('http://localhost/api/events/00000000-0000-0000-0000-000000000001'),
+          {
+            params: { id: baseEvent.id },
+          },
+        )
+
+      expect(response.status).toBe(204)
+      expect(deleteEvent).toHaveBeenCalledWith(baseEvent.id)
+    })
+
+    it('returns 404 when the event does not exist', async () => {
+      const user = { id: baseEvent.organizerId, role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      ;(getEventById as jest.Mock).mockResolvedValue(undefined)
+
+      const response = await deleteEventRoute(
+        createRequest('http://localhost/api/events/00000000-0000-0000-0000-000000000001'),
+        {
+          params: { id: baseEvent.id },
+        },
+      )
+
+      expect(response.status).toBe(404)
+    })
+  })
+})

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { HttpError, getSessionUser, requireUser } from '@server/auth'
+import {
+  createEvent,
+  eventCreateSchema,
+  listEvents,
+  serializeEvent,
+} from '@server/events'
+
+const querySchema = z.object({
+  category: z.string().trim().min(2).max(120).optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+})
+
+const RATE_LIMIT_ENDPOINT: Parameters<typeof checkRateLimit>[1] = 'post_event'
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const rawCategory = searchParams.get('category')
+    const rawLimit = searchParams.get('limit')
+
+    const parsed = querySchema.safeParse({
+      category: rawCategory && rawCategory.trim().length > 0 ? rawCategory.trim() : undefined,
+      limit: rawLimit ?? undefined,
+    })
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid query parameters',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const sessionUser = await getSessionUser()
+    const events = await listEvents({
+      category: parsed.data.category,
+      limit: parsed.data.limit,
+      sessionUser,
+    })
+
+    return NextResponse.json({ events: events.map(serializeEvent) })
+  } catch (error) {
+    console.error('Failed to list events', error)
+    return NextResponse.json(
+      { error: 'Failed to load events' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const user = await requireUser()
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000),
+      )
+
+      return NextResponse.json(
+        {
+          error: 'Too many event submissions. Please try again later.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(retryAfterSeconds) },
+        },
+      )
+    }
+
+    const body = await request.json()
+    const parsed = eventCreateSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const event = await createEvent(parsed.data, user.id)
+
+    return NextResponse.json({ event: serializeEvent(event) }, { status: 201 })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: 'Invalid JSON payload' },
+        { status: 400 },
+      )
+    }
+
+    console.error('Failed to create event', error)
+    return NextResponse.json(
+      { error: 'Failed to create event' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/lib/rate-limiting.ts
+++ b/src/lib/rate-limiting.ts
@@ -31,6 +31,7 @@ export const RATE_LIMIT_CONFIGS = {
   // Content creation
   post_business: { windowMs: 60 * 60 * 1000, maxRequests: 5 }, // 5 business posts per hour
   post_provider: { windowMs: 60 * 60 * 1000, maxRequests: 8 }, // 8 provider writes per hour
+  post_event: { windowMs: 60 * 60 * 1000, maxRequests: 8 }, // 8 event writes per hour
   post_listing: { windowMs: 60 * 60 * 1000, maxRequests: 10 }, // 10 listings per hour
   post_message: { windowMs: 60 * 1000, maxRequests: 20 }, // 20 messages per minute
   post_review: { windowMs: 60 * 60 * 1000, maxRequests: 5 }, // 5 reviews per hour


### PR DESCRIPTION
## Summary
- add Drizzle migration and schema updates to support event categories and RSVP model definitions
- implement server-side events utilities plus Next.js API routes for listing, creating, updating, and deleting events with validation and rate limiting
- cover the new routes with Jest tests

## Testing
- npm test -- --runTestsByPath src/app/api/events/__tests__/routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc2b70a654832bb13f665136933106