### PR TITLE
Implement announcements API with approval workflow

### DIFF
--- a/server/announcements.ts
+++ b/server/announcements.ts
@@ -1,0 +1,132 @@
+import { and, desc, eq, or, type SQL } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { announcements, db, type Announcement, type NewAnnouncement } from '@/lib/db'
+import {
+  announcementAudiences,
+  announcementTypes,
+  type UserRole,
+} from '@shared/schema'
+
+const MAX_BODY_LENGTH = 10_000
+const MAX_TITLE_LENGTH = 255
+const MAX_LIST_LIMIT = 50
+
+const nonEmptyTrimmedString = (min: number, max: number) =>
+  z.string().trim().min(min).max(max)
+
+const normaliseOptionalEnum = <T extends string>(value: T | undefined, fallback: T) =>
+  value ?? fallback
+
+const sanitizeExtra = (value: unknown) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {} as Record<string, unknown>
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value)) as Record<string, unknown>
+  } catch {
+    return {} as Record<string, unknown>
+  }
+}
+
+const sanitizeAttachments = (value: unknown) => {
+  if (!Array.isArray(value)) {
+    return [] as unknown[]
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value)) as unknown[]
+  } catch {
+    return [] as unknown[]
+  }
+}
+
+export const announcementCreateSchema = z.object({
+  type: z.enum(announcementTypes),
+  title: nonEmptyTrimmedString(3, MAX_TITLE_LENGTH),
+  body: nonEmptyTrimmedString(1, MAX_BODY_LENGTH),
+  audience: z.enum(announcementAudiences).optional(),
+  extra: z.record(z.unknown()).optional(),
+})
+
+export type AnnouncementCreateInput = z.infer<typeof announcementCreateSchema>
+
+export type AnnouncementListOptions = {
+  limit?: number
+  sessionUser?: { id: string; role: UserRole } | null
+}
+
+export async function listAnnouncements(options: AnnouncementListOptions = {}) {
+  const { limit = MAX_LIST_LIMIT, sessionUser } = options
+  const normalizedLimit = Math.max(1, Math.min(MAX_LIST_LIMIT, limit))
+
+  const filters: SQL[] = []
+
+  if (!sessionUser || sessionUser.role !== 'admin') {
+    if (sessionUser) {
+      filters.push(or(eq(announcements.isApproved, true), eq(announcements.authorId, sessionUser.id)))
+    } else {
+      filters.push(eq(announcements.isApproved, true))
+    }
+  }
+
+  let query = db
+    .select()
+    .from(announcements)
+    .orderBy(desc(announcements.createdAt))
+    .limit(normalizedLimit)
+
+  if (filters.length === 1) {
+    query = query.where(filters[0])
+  } else if (filters.length > 1) {
+    query = query.where(and(...filters))
+  }
+
+  return query
+}
+
+export async function createAnnouncement(
+  input: AnnouncementCreateInput,
+  author: { id: string; role: UserRole },
+) {
+  const payload = announcementCreateSchema.parse(input)
+  const now = new Date()
+  const isApproved = author.role === 'admin'
+
+  const values: NewAnnouncement = {
+    authorId: author.id,
+    title: payload.title.trim(),
+    body: payload.body.trim(),
+    type: payload.type,
+    audience: normaliseOptionalEnum(payload.audience, 'public'),
+    isApproved,
+    publishedAt: isApproved ? now : null,
+    extra: sanitizeExtra(payload.extra),
+  }
+
+  const [announcement] = await db.insert(announcements).values(values).returning()
+
+  return announcement
+}
+
+export const serializeAnnouncement = (announcement: Announcement) => {
+  return {
+    id: announcement.id,
+    authorId: announcement.authorId,
+    title: announcement.title,
+    body: announcement.body,
+    type: announcement.type,
+    audience: announcement.audience,
+    isApproved: announcement.isApproved,
+    publishedAt: announcement.publishedAt ? announcement.publishedAt.toISOString() : null,
+    expiresAt: announcement.expiresAt ? announcement.expiresAt.toISOString() : null,
+    attachments: sanitizeAttachments(announcement.attachments),
+    extra: sanitizeExtra(announcement.extra),
+    createdAt: announcement.createdAt.toISOString(),
+    updatedAt: announcement.updatedAt.toISOString(),
+  }
+}
+
+export type SerializedAnnouncement = ReturnType<typeof serializeAnnouncement>
+

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -413,9 +413,13 @@ export const announcements = pgTable(
       .notNull()
       .default("public")
       .$type<AnnouncementAudience>(),
+    isApproved: boolean("is_approved")
+      .notNull()
+      .default(false),
     publishedAt: timestamp("published_at", { withTimezone: true }),
     expiresAt: timestamp("expires_at", { withTimezone: true }),
     attachments: jsonb("attachments").default(sql`'[]'::jsonb`).notNull(),
+    extra: jsonb("extra").default(sql`'{}'::jsonb`).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),

--- a/src/app/api/announcements/__tests__/routes.test.ts
+++ b/src/app/api/announcements/__tests__/routes.test.ts
@@ -1,0 +1,240 @@
+jest.mock('@server/announcements', () => {
+  const actual = jest.requireActual('@server/announcements')
+  return {
+    ...actual,
+    listAnnouncements: jest.fn(),
+    createAnnouncement: jest.fn(),
+    serializeAnnouncement: jest.fn((value: unknown) => value),
+  }
+})
+
+jest.mock('@server/auth', () => {
+  const actual = jest.requireActual('@server/auth')
+  return {
+    ...actual,
+    getSessionUser: jest.fn(),
+    requireUser: jest.fn(),
+  }
+})
+
+jest.mock('@/lib/rate-limiting', () => ({
+  checkRateLimit: jest.fn(),
+}))
+
+const createRequest = (
+  url: string,
+  init?: { method?: string; body?: unknown; headers?: Record<string, string> },
+) => {
+  const serializedBody =
+    typeof init?.body === 'string' ? init.body : init?.body !== undefined ? JSON.stringify(init.body) : undefined
+  const headerStore = new Map<string, string>()
+
+  if (init?.headers) {
+    for (const [key, value] of Object.entries(init.headers)) {
+      headerStore.set(key.toLowerCase(), value)
+    }
+  }
+
+  if (serializedBody && !headerStore.has('content-type')) {
+    headerStore.set('content-type', 'application/json')
+  }
+
+  return {
+    url,
+    method: init?.method ?? 'GET',
+    headers: {
+      get(name: string) {
+        return headerStore.get(name.toLowerCase()) ?? null
+      },
+      has(name: string) {
+        return headerStore.has(name.toLowerCase())
+      },
+    },
+    async json() {
+      if (!serializedBody) {
+        throw new Error('No JSON body present')
+      }
+      return JSON.parse(serializedBody)
+    },
+    async text() {
+      return serializedBody ?? ''
+    },
+  } as unknown as Request
+}
+
+import { GET as listAnnouncementsRoute, POST as createAnnouncementRoute } from '../route'
+import {
+  createAnnouncement,
+  listAnnouncements,
+  serializeAnnouncement,
+} from '@server/announcements'
+import { getSessionUser, requireUser, UnauthorizedError } from '@server/auth'
+import { checkRateLimit } from '@/lib/rate-limiting'
+
+describe('Announcements API routes', () => {
+  const baseAnnouncement = {
+    id: '00000000-0000-0000-0000-000000000001',
+    authorId: '00000000-0000-0000-0000-000000000999',
+    title: 'Important Update',
+    body: 'This is a critical update for the community.',
+    type: 'urgent',
+    audience: 'public',
+    isApproved: true,
+    publishedAt: new Date('2024-07-01T10:00:00Z'),
+    expiresAt: null,
+    attachments: [],
+    extra: { severity: 'high' },
+    createdAt: new Date('2024-07-01T09:00:00Z'),
+    updatedAt: new Date('2024-07-01T09:30:00Z'),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET /api/announcements', () => {
+    it('returns announcements for the current session user', async () => {
+      const sessionUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' }
+      ;(getSessionUser as jest.Mock).mockResolvedValue(sessionUser)
+      ;(listAnnouncements as jest.Mock).mockResolvedValue([baseAnnouncement])
+      ;(serializeAnnouncement as jest.Mock).mockReturnValue({
+        id: baseAnnouncement.id,
+        title: baseAnnouncement.title,
+      })
+
+      const response = await listAnnouncementsRoute(createRequest('http://localhost/api/announcements'))
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload.announcements).toEqual([
+        expect.objectContaining({ id: baseAnnouncement.id, title: baseAnnouncement.title }),
+      ])
+      expect(listAnnouncements).toHaveBeenCalledWith({ sessionUser })
+    })
+
+    it('handles unexpected failures gracefully', async () => {
+      ;(getSessionUser as jest.Mock).mockResolvedValue(null)
+      ;(listAnnouncements as jest.Mock).mockRejectedValue(new Error('database unavailable'))
+
+      const response = await listAnnouncementsRoute(createRequest('http://localhost/api/announcements'))
+
+      expect(response.status).toBe(500)
+      const payload = await response.json()
+      expect(payload.error).toBe('Failed to load announcements')
+    })
+  })
+
+  describe('POST /api/announcements', () => {
+    it('requires authentication', async () => {
+      ;(requireUser as jest.Mock).mockRejectedValue(new UnauthorizedError())
+
+      const response = await createAnnouncementRoute(
+        createRequest('http://localhost/api/announcements', {
+          method: 'POST',
+          body: {},
+        }),
+      )
+
+      expect(response.status).toBe(401)
+    })
+
+    it('enforces rate limiting when submissions are too frequent', async () => {
+      const user = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      const resetTime = new Date('2024-07-02T10:00:00Z')
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: false,
+        remaining: 0,
+        resetTime,
+        blocked: false,
+      })
+
+      const response = await createAnnouncementRoute(
+        createRequest('http://localhost/api/announcements', {
+          method: 'POST',
+          body: {
+            type: 'general',
+            title: 'Community Update',
+            body: 'Welcome to the community!',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(429)
+      expect(response.headers.get('Retry-After')).toBeDefined()
+      const payload = await response.json()
+      expect(payload.retryAfter).toBe(resetTime.toISOString())
+    })
+
+    it('validates the incoming payload', async () => {
+      const user = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 10,
+        resetTime: new Date('2024-07-02T10:00:00Z'),
+        blocked: false,
+      })
+
+      const response = await createAnnouncementRoute(
+        createRequest('http://localhost/api/announcements', {
+          method: 'POST',
+          body: {
+            type: 'unknown-type',
+            title: 'Hi',
+            body: 'Short body',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.error).toBe('Validation failed')
+    })
+
+    it('creates an announcement when payload is valid', async () => {
+      const user = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 11,
+        resetTime: new Date('2024-07-02T10:00:00Z'),
+        blocked: false,
+      })
+
+      ;(createAnnouncement as jest.Mock).mockResolvedValue(baseAnnouncement)
+      ;(serializeAnnouncement as jest.Mock).mockReturnValue({
+        id: baseAnnouncement.id,
+        title: baseAnnouncement.title,
+        isApproved: baseAnnouncement.isApproved,
+      })
+
+      const response = await createAnnouncementRoute(
+        createRequest('http://localhost/api/announcements', {
+          method: 'POST',
+          body: {
+            type: 'urgent',
+            title: 'Important Update',
+            body: 'This is a critical update for the community.',
+            extra: { severity: 'high' },
+          },
+        }),
+      )
+
+      expect(response.status).toBe(201)
+      const payload = await response.json()
+      expect(payload.announcement).toEqual(
+        expect.objectContaining({ id: baseAnnouncement.id, isApproved: true }),
+      )
+      expect(createAnnouncement).toHaveBeenCalledWith(
+        {
+          type: 'urgent',
+          title: 'Important Update',
+          body: 'This is a critical update for the community.',
+          extra: { severity: 'high' },
+        },
+        user,
+      )
+    })
+  })
+})

--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { HttpError, getSessionUser, requireUser } from '@server/auth'
+import {
+  announcementCreateSchema,
+  createAnnouncement,
+  listAnnouncements,
+  serializeAnnouncement,
+} from '@server/announcements'
+
+const RATE_LIMIT_ENDPOINT: Parameters<typeof checkRateLimit>[1] = 'post_announcement'
+
+export async function GET() {
+  try {
+    const sessionUser = await getSessionUser()
+    const announcements = await listAnnouncements({ sessionUser })
+
+    return NextResponse.json({
+      announcements: announcements.map(serializeAnnouncement),
+    })
+  } catch (error) {
+    console.error('Failed to list announcements', error)
+    return NextResponse.json(
+      { error: 'Failed to load announcements' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const user = await requireUser()
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000),
+      )
+
+      return NextResponse.json(
+        {
+          error: 'Too many announcements submitted. Please try again later.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(retryAfterSeconds) },
+        },
+      )
+    }
+
+    const body = await request.json()
+    const parsed = announcementCreateSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const announcement = await createAnnouncement(parsed.data, user)
+
+    return NextResponse.json(
+      { announcement: serializeAnnouncement(announcement) },
+      { status: 201 },
+    )
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: 'Invalid JSON payload' },
+        { status: 400 },
+      )
+    }
+
+    console.error('Failed to create announcement', error)
+    return NextResponse.json(
+      { error: 'Failed to create announcement' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/lib/rate-limiting.ts
+++ b/src/lib/rate-limiting.ts
@@ -32,6 +32,7 @@ export const RATE_LIMIT_CONFIGS = {
   post_business: { windowMs: 60 * 60 * 1000, maxRequests: 5 }, // 5 business posts per hour
   post_provider: { windowMs: 60 * 60 * 1000, maxRequests: 8 }, // 8 provider writes per hour
   post_event: { windowMs: 60 * 60 * 1000, maxRequests: 8 }, // 8 event writes per hour
+  post_announcement: { windowMs: 60 * 60 * 1000, maxRequests: 12 }, // 12 announcements per hour
   post_listing: { windowMs: 60 * 60 * 1000, maxRequests: 10 }, // 10 listings per hour
   post_message: { windowMs: 60 * 1000, maxRequests: 20 }, // 20 messages per minute
   post_review: { windowMs: 60 * 60 * 1000, maxRequests: 5 }, // 5 reviews per hour


### PR DESCRIPTION
## Summary
- add approval and extra metadata fields to announcements schema and rate limit configuration
- implement announcements server utilities and Next.js API route with auto-approval for admins
- cover the announcements endpoint with Jest tests for auth, validation, and rate limiting

## Testing
- npm test -- src/app/api/announcements
- npm run type-check *(fails: existing repository type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc691a4ffc832b8297be3b304379a0