### PR TITLE
Add classifieds API with validation and tests

### DIFF
--- a/server/classifieds.ts
+++ b/server/classifieds.ts
@@ -1,0 +1,302 @@
+import { and, desc, eq, ilike, or, type SQL } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { db, classifieds, type InsertClassified } from '@/lib/db'
+import {
+  classifiedStatuses,
+  classifiedTypes,
+  type Classified,
+  type UserRole,
+} from '@shared/schema'
+
+import { HttpError } from './auth'
+
+const nonEmptyTrimmedString = (min: number, max: number) =>
+  z.string().trim().min(min).max(max)
+
+const isoDateTimeWithOffset = z.string().datetime({ offset: true })
+
+const priceSchema = z
+  .coerce.number({ invalid_type_error: 'Price must be a number' })
+  .min(0, 'Price cannot be negative')
+  .max(1_000_000, 'Price exceeds the supported range')
+  .refine((value) => Number.isFinite(value) && Number.parseFloat(value.toFixed(2)) === value, {
+    message: 'Price must have at most two decimal places',
+  })
+
+const contactInfoSchema = z
+  .record(z.string().trim().min(1).max(255))
+  .optional()
+
+const metadataSchema = z.record(z.unknown()).optional()
+
+const imageUrlsSchema = z
+  .array(z.string().trim().url().max(2048))
+  .max(10)
+  .optional()
+
+export const classifiedCreateSchema = z.object({
+  title: nonEmptyTrimmedString(3, 255),
+  description: nonEmptyTrimmedString(10, 10_000),
+  category: nonEmptyTrimmedString(2, 120).optional(),
+  type: z.enum(classifiedTypes).optional(),
+  status: z.enum(classifiedStatuses).optional(),
+  price: priceSchema.optional(),
+  currency: z
+    .string()
+    .trim()
+    .length(3)
+    .optional(),
+  location: nonEmptyTrimmedString(2, 255).optional(),
+  expiresAt: isoDateTimeWithOffset.optional(),
+  contactInfo: contactInfoSchema,
+  metadata: metadataSchema,
+  imageUrls: imageUrlsSchema,
+})
+
+export type ClassifiedCreateInput = z.infer<typeof classifiedCreateSchema>
+
+export type ClassifiedListOptions = {
+  query?: string | null
+  category?: string | null
+  limit?: number
+  sessionUser?: { id: string; role: UserRole } | null
+}
+
+const normaliseOptionalString = (value?: string | null) => {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (value === null) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const normaliseCurrency = (value?: string) => {
+  if (!value) {
+    return 'USD'
+  }
+
+  return value.trim().toUpperCase()
+}
+
+const normaliseContactInfo = (
+  value?: Record<string, string>,
+): Record<string, string> => {
+  if (!value) {
+    return {}
+  }
+
+  const entries: Record<string, string> = {}
+
+  for (const [rawKey, rawValue] of Object.entries(value)) {
+    const key = rawKey.trim()
+    const val = rawValue.trim()
+
+    if (key.length > 0 && val.length > 0) {
+      entries[key] = val
+    }
+  }
+
+  return entries
+}
+
+const normaliseMetadata = (value?: Record<string, unknown>) => {
+  if (!value) {
+    return {}
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value)) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+const normaliseImageUrls = (value?: string[]) => {
+  if (!value) {
+    return [] as string[]
+  }
+
+  const urls = [] as string[]
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    const trimmed = entry.trim()
+    if (trimmed.length === 0) {
+      continue
+    }
+
+    if (!seen.has(trimmed)) {
+      urls.push(trimmed)
+      seen.add(trimmed)
+    }
+  }
+
+  return urls
+}
+
+const toUtcDate = (value: string) => {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    throw new HttpError(400, 'Invalid date value received')
+  }
+
+  return new Date(date.toISOString())
+}
+
+const toNumericString = (value?: number) => {
+  if (value === undefined) {
+    return undefined
+  }
+
+  const scaled = Math.round(value * 100)
+  return (scaled / 100).toFixed(2)
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const extractContactInfo = (value: unknown): Record<string, string> => {
+  if (!isPlainObject(value)) {
+    return {}
+  }
+
+  const result: Record<string, string> = {}
+  for (const [key, rawValue] of Object.entries(value)) {
+    if (typeof rawValue === 'string') {
+      const trimmedKey = key.trim()
+      const trimmedValue = rawValue.trim()
+      if (trimmedKey.length > 0 && trimmedValue.length > 0) {
+        result[trimmedKey] = trimmedValue
+      }
+    }
+  }
+
+  return result
+}
+
+const extractImageUrls = (metadata: unknown): string[] => {
+  if (!isPlainObject(metadata)) {
+    return []
+  }
+
+  const images = metadata.images
+
+  if (!Array.isArray(images)) {
+    return []
+  }
+
+  const urls: string[] = []
+  for (const entry of images) {
+    if (typeof entry === 'string') {
+      const trimmed = entry.trim()
+      if (trimmed.length > 0) {
+        urls.push(trimmed)
+      }
+    }
+  }
+
+  return urls
+}
+
+export async function listClassifieds(options: ClassifiedListOptions = {}) {
+  const { query, category, limit = 50, sessionUser } = options
+  const conditions: SQL[] = []
+
+  if (query && query.trim().length > 0) {
+    conditions.push(ilike(classifieds.title, `%${query.trim()}%`))
+  }
+
+  if (category && category.trim().length > 0) {
+    conditions.push(eq(classifieds.category, category.trim()))
+  }
+
+  if (!sessionUser || sessionUser.role !== 'admin') {
+    if (sessionUser) {
+      conditions.push(
+        or(eq(classifieds.ownerId, sessionUser.id), eq(classifieds.status, 'published')),
+      )
+    } else {
+      conditions.push(eq(classifieds.status, 'published'))
+    }
+  }
+
+  let queryBuilder = db
+    .select()
+    .from(classifieds)
+    .orderBy(desc(classifieds.createdAt))
+    .limit(Math.max(1, Math.min(100, limit)))
+
+  if (conditions.length === 1) {
+    queryBuilder = queryBuilder.where(conditions[0])
+  } else if (conditions.length > 1) {
+    queryBuilder = queryBuilder.where(and(...conditions))
+  }
+
+  return queryBuilder
+}
+
+export async function createClassified(
+  input: ClassifiedCreateInput,
+  ownerId: string,
+) {
+  const now = new Date()
+  const metadata = normaliseMetadata(input.metadata)
+  const imageUrls = normaliseImageUrls(input.imageUrls)
+
+  if (imageUrls.length > 0) {
+    metadata.images = imageUrls
+  }
+
+  const values: InsertClassified = {
+    ownerId,
+    title: input.title.trim(),
+    description: input.description.trim(),
+    type: input.type ?? 'offer',
+    status: input.status ?? 'draft',
+    category: normaliseOptionalString(input.category) ?? null,
+    price:
+      input.price !== undefined ? toNumericString(input.price) ?? null : null,
+    currency: normaliseCurrency(input.currency),
+    location: normaliseOptionalString(input.location) ?? null,
+    expiresAt: input.expiresAt ? toUtcDate(input.expiresAt) : null,
+    contactInfo: normaliseContactInfo(input.contactInfo),
+    metadata,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  const [classified] = await db
+    .insert(classifieds)
+    .values(values)
+    .returning()
+
+  return classified
+}
+
+export const serializeClassified = (classified: Classified) => {
+  const price = classified.price ? Number.parseFloat(classified.price) : null
+
+  return {
+    id: classified.id,
+    ownerId: classified.ownerId,
+    title: classified.title,
+    description: classified.description,
+    type: classified.type,
+    status: classified.status,
+    category: classified.category,
+    price,
+    currency: classified.currency,
+    location: classified.location,
+    expiresAt: classified.expiresAt ? classified.expiresAt.toISOString() : null,
+    contactInfo: extractContactInfo(classified.contactInfo),
+    imageUrls: extractImageUrls(classified.metadata),
+    createdAt: classified.createdAt.toISOString(),
+    updatedAt: classified.updatedAt.toISOString(),
+  }
+}

--- a/src/app/api/classifieds/__tests__/route.test.ts
+++ b/src/app/api/classifieds/__tests__/route.test.ts
@@ -1,0 +1,258 @@
+jest.mock('@server/classifieds', () => {
+  const actual = jest.requireActual('@server/classifieds')
+  return {
+    ...actual,
+    listClassifieds: jest.fn(),
+    createClassified: jest.fn(),
+  }
+})
+
+jest.mock('@server/auth', () => {
+  const actual = jest.requireActual('@server/auth')
+  return {
+    ...actual,
+    getSessionUser: jest.fn(),
+    requireUser: jest.fn(),
+  }
+})
+
+jest.mock('@/lib/rate-limiting', () => ({
+  checkRateLimit: jest.fn(),
+}))
+
+const createRequest = (
+  url: string,
+  init?: { method?: string; body?: unknown; headers?: Record<string, string> },
+) => {
+  const serializedBody =
+    typeof init?.body === 'string'
+      ? init.body
+      : init?.body !== undefined
+      ? JSON.stringify(init.body)
+      : undefined
+  const headerStore = new Map<string, string>()
+
+  if (init?.headers) {
+    for (const [key, value] of Object.entries(init.headers)) {
+      headerStore.set(key.toLowerCase(), value)
+    }
+  }
+
+  if (serializedBody && !headerStore.has('content-type')) {
+    headerStore.set('content-type', 'application/json')
+  }
+
+  return {
+    url,
+    method: init?.method ?? 'GET',
+    headers: {
+      get(name: string) {
+        return headerStore.get(name.toLowerCase()) ?? null
+      },
+      has(name: string) {
+        return headerStore.has(name.toLowerCase())
+      },
+    },
+    async json() {
+      if (!serializedBody) {
+        throw new Error('No JSON body present')
+      }
+      return JSON.parse(serializedBody)
+    },
+    async text() {
+      return serializedBody ?? ''
+    },
+  } as unknown as Request
+}
+
+import { GET as listClassifiedsRoute, POST as createClassifiedRoute } from '../route'
+import {
+  createClassified,
+  listClassifieds,
+  serializeClassified,
+} from '@server/classifieds'
+import { getSessionUser, requireUser, UnauthorizedError } from '@server/auth'
+import { checkRateLimit } from '@/lib/rate-limiting'
+
+const baseClassified = {
+  id: '00000000-0000-0000-0000-000000000021',
+  ownerId: '00000000-0000-0000-0000-000000000099',
+  title: 'Gently Used Sofa',
+  description: 'Comfortable three-seat sofa in great condition.',
+  type: 'offer',
+  status: 'published',
+  category: 'furniture',
+  price: '120.50',
+  currency: 'AUD',
+  location: 'Brisbane, QLD',
+  expiresAt: new Date('2024-09-01T00:00:00Z'),
+  contactInfo: {
+    email: 'seller@example.com',
+    phone: '+61000000000',
+  },
+  metadata: {
+    images: [
+      'https://images.example.com/classifieds/sofa-1.jpg',
+      'https://images.example.com/classifieds/sofa-2.jpg',
+    ],
+  },
+  createdAt: new Date('2024-07-01T12:00:00Z'),
+  updatedAt: new Date('2024-07-02T12:00:00Z'),
+} as const
+
+describe('Classifieds API routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET /api/classifieds', () => {
+    it('returns classifieds filtered by search parameters', async () => {
+      const sessionUser = {
+        id: 'member-1',
+        role: 'member',
+        email: 'member@example.com',
+        status: 'active',
+      }
+      ;(getSessionUser as jest.Mock).mockResolvedValue(sessionUser)
+      ;(listClassifieds as jest.Mock).mockResolvedValue([baseClassified])
+
+      const response = await listClassifiedsRoute(
+        createRequest(
+          'http://localhost/api/classifieds?q=%20sofa%20&category=%20furniture%20',
+        ),
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload.classifieds).toHaveLength(1)
+      expect(payload.classifieds[0]).toEqual(
+        expect.objectContaining({
+          id: baseClassified.id,
+          title: baseClassified.title,
+          price: 120.5,
+          imageUrls: baseClassified.metadata.images,
+        }),
+      )
+      expect(listClassifieds).toHaveBeenCalledWith({
+        query: 'sofa',
+        category: 'furniture',
+        sessionUser,
+      })
+    })
+
+    it('rejects invalid filters', async () => {
+      const response = await listClassifiedsRoute(
+        createRequest('http://localhost/api/classifieds?q=s'),
+      )
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.error).toBe('Invalid query parameters')
+    })
+  })
+
+  describe('POST /api/classifieds', () => {
+    it('requires authentication', async () => {
+      ;(requireUser as jest.Mock).mockRejectedValue(new UnauthorizedError())
+
+      const response = await createClassifiedRoute(
+        createRequest('http://localhost/api/classifieds', {
+          method: 'POST',
+          body: {},
+        }),
+      )
+
+      expect(response.status).toBe(401)
+    })
+
+    it('enforces rate limiting', async () => {
+      const user = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      const resetTime = new Date('2024-07-10T10:00:00Z')
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: false,
+        remaining: 0,
+        resetTime,
+        blocked: false,
+      })
+
+      const response = await createClassifiedRoute(
+        createRequest('http://localhost/api/classifieds', {
+          method: 'POST',
+          body: {
+            title: 'Gently Used Sofa',
+            description: 'Comfortable three-seat sofa in great condition.',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(429)
+      const payload = await response.json()
+      expect(payload.retryAfter).toBe(resetTime.toISOString())
+    })
+
+    it('validates payload before creating a classified', async () => {
+      const user = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 9,
+        resetTime: new Date('2024-07-10T10:00:00Z'),
+        blocked: false,
+      })
+
+      const response = await createClassifiedRoute(
+        createRequest('http://localhost/api/classifieds', {
+          method: 'POST',
+          body: {
+            title: 'x',
+            description: 'short',
+          },
+        }),
+      )
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.error).toBe('Validation failed')
+      expect(createClassified).not.toHaveBeenCalled()
+    })
+
+    it('creates a classified listing when payload is valid', async () => {
+      const user = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' }
+      ;(requireUser as jest.Mock).mockResolvedValue(user)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: true,
+        remaining: 9,
+        resetTime: new Date('2024-07-10T10:00:00Z'),
+        blocked: false,
+      })
+      ;(createClassified as jest.Mock).mockResolvedValue(baseClassified)
+
+      const response = await createClassifiedRoute(
+        createRequest('http://localhost/api/classifieds', {
+          method: 'POST',
+          body: {
+            title: 'Gently Used Sofa',
+            description: 'Comfortable three-seat sofa in great condition.',
+            category: 'furniture',
+            price: 120.5,
+            currency: 'aud',
+            imageUrls: baseClassified.metadata.images,
+          },
+        }),
+      )
+
+      expect(response.status).toBe(201)
+      const payload = await response.json()
+      expect(payload.classified).toEqual(serializeClassified(baseClassified))
+      expect(createClassified).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Gently Used Sofa',
+          category: 'furniture',
+          imageUrls: baseClassified.metadata.images,
+        }),
+        user.id,
+      )
+    })
+  })
+})

--- a/src/app/api/classifieds/route.ts
+++ b/src/app/api/classifieds/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import {
+  classifiedCreateSchema,
+  createClassified,
+  listClassifieds,
+  serializeClassified,
+} from '@server/classifieds'
+import { HttpError, getSessionUser, requireUser } from '@server/auth'
+
+const querySchema = z.object({
+  q: z.string().trim().min(2).max(255).optional(),
+  category: z.string().trim().min(2).max(120).optional(),
+})
+
+const RATE_LIMIT_ENDPOINT: Parameters<typeof checkRateLimit>[1] = 'post_listing'
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const rawQuery = searchParams.get('q')
+    const rawCategory = searchParams.get('category')
+
+    const parsed = querySchema.safeParse({
+      q: rawQuery && rawQuery.trim().length > 0 ? rawQuery.trim() : undefined,
+      category:
+        rawCategory && rawCategory.trim().length > 0 ? rawCategory.trim() : undefined,
+    })
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid query parameters',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const sessionUser = await getSessionUser()
+    const classifieds = await listClassifieds({
+      query: parsed.data.q,
+      category: parsed.data.category,
+      sessionUser,
+    })
+
+    return NextResponse.json({
+      classifieds: classifieds.map(serializeClassified),
+    })
+  } catch (error) {
+    console.error('Failed to list classifieds', error)
+    return NextResponse.json(
+      { error: 'Failed to load classifieds' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const user = await requireUser()
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000),
+      )
+
+      return NextResponse.json(
+        {
+          error: 'Too many listing submissions. Please try again later.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(retryAfterSeconds) },
+        },
+      )
+    }
+
+    const body = await request.json()
+    const parsed = classifiedCreateSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const classified = await createClassified(parsed.data, user.id)
+
+    return NextResponse.json(
+      { classified: serializeClassified(classified) },
+      { status: 201 },
+    )
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: 'Invalid JSON payload' },
+        { status: 400 },
+      )
+    }
+
+    console.error('Failed to create classified', error)
+    return NextResponse.json(
+      { error: 'Failed to create classified' },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add classifieds server module with schemas, RBAC-aware listing, and metadata normalization for multi-image support
- expose GET/POST handlers for /api/classifieds with query validation, rate limiting, and session-based author attribution
- cover classifieds API behaviours with Jest tests for listing, validation, rate limiting, and creation flows

## Testing
- npm test -- src/app/api/classifieds/__tests__/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc7052d684832bb78136ba7c51207e