### PR TITLE
Implement messaging API routes

### DIFF
--- a/server/messages.ts
+++ b/server/messages.ts
@@ -1,0 +1,340 @@
+import { and, asc, eq, gt, ne, sql, type SQL } from 'drizzle-orm'
+import { z } from 'zod'
+
+import {
+  conversations,
+  db,
+  messages,
+  participants,
+  users,
+  type Conversation,
+  type Message,
+  type Participant,
+} from '@/lib/db'
+import type { SessionUser } from '@server/auth'
+import { ForbiddenError, HttpError } from '@server/auth'
+
+type MinimalUser = Pick<SessionUser, 'id' | 'role'>
+
+type ConversationMetadata = Record<string, unknown>
+
+type TransactionLike = typeof db
+
+const MAX_MESSAGE_LENGTH = 5000
+const MAX_SUBJECT_LENGTH = 255
+const CONTEXT_TYPE_MAX_LENGTH = 64
+const CONTEXT_REFERENCE_MAX_LENGTH = 255
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+export const conversationContextSchema = z
+  .object({
+    type: z.string().trim().min(1).max(CONTEXT_TYPE_MAX_LENGTH),
+    entityId: z.string().uuid().optional(),
+    reference: z.string().trim().min(1).max(CONTEXT_REFERENCE_MAX_LENGTH).optional(),
+    metadata: z.record(z.unknown()).optional(),
+  })
+  .strict()
+
+export const startConversationSchema = z.object({
+  targetUserId: z.string().uuid(),
+  subject: z.string().trim().min(1).max(MAX_SUBJECT_LENGTH).optional(),
+  context: conversationContextSchema.optional(),
+  firstMessage: z.string().trim().min(1).max(MAX_MESSAGE_LENGTH),
+})
+
+export const messageCreateSchema = z.object({
+  body: z.string().trim().min(1).max(MAX_MESSAGE_LENGTH),
+})
+
+export type StartConversationInput = z.infer<typeof startConversationSchema>
+export type MessageCreateInput = z.infer<typeof messageCreateSchema>
+
+export type ConversationWithMessages = {
+  conversation: Conversation
+  messages: Message[]
+  participant: Participant | null
+  unreadCount: number
+}
+
+export type StartConversationResult = {
+  conversation: Conversation
+  participants: Participant[]
+  message: Message
+  unreadCount: number
+}
+
+export type MessageCreationResult = {
+  conversation: Conversation
+  message: Message
+  unreadCount: number
+}
+
+export type ConversationContext = z.infer<typeof conversationContextSchema>
+
+export function serializeConversation(conversation: Conversation) {
+  const rawMetadata = conversation.metadata as ConversationMetadata | null
+  const rawContext = rawMetadata?.context
+
+  const context = isPlainRecord(rawContext) ? (rawContext as ConversationContext) : null
+
+  return {
+    id: conversation.id,
+    createdBy: conversation.createdBy,
+    topic: conversation.topic,
+    isGroup: conversation.isGroup,
+    createdAt: conversation.createdAt.toISOString(),
+    updatedAt: conversation.updatedAt.toISOString(),
+    context,
+  }
+}
+
+export function serializeMessage(message: Message) {
+  return {
+    id: message.id,
+    conversationId: message.conversationId,
+    senderId: message.senderId,
+    type: message.type,
+    status: message.status,
+    body: message.body,
+    attachments: message.attachments,
+    createdAt: message.createdAt.toISOString(),
+    updatedAt: message.updatedAt.toISOString(),
+    deliveredAt: message.deliveredAt ? message.deliveredAt.toISOString() : null,
+    readAt: message.readAt ? message.readAt.toISOString() : null,
+  }
+}
+
+export async function startConversation(
+  input: StartConversationInput,
+  user: MinimalUser,
+): Promise<StartConversationResult> {
+  if (input.targetUserId === user.id) {
+    throw new HttpError(400, 'Cannot start a conversation with yourself')
+  }
+
+  const [target] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, input.targetUserId))
+    .limit(1)
+
+  if (!target) {
+    throw new HttpError(404, 'Target user not found')
+  }
+
+  const now = new Date()
+
+  const { conversation, participants: insertedParticipants, message } = await db.transaction(
+    async (tx) => {
+      const conversationMetadata: ConversationMetadata = input.context
+        ? { context: input.context }
+        : {}
+
+      const [createdConversation] = await tx
+        .insert(conversations)
+        .values({
+          createdBy: user.id,
+          topic: input.subject ?? null,
+          isGroup: false,
+          ...(Object.keys(conversationMetadata).length > 0
+            ? { metadata: conversationMetadata }
+            : {}),
+        })
+        .returning()
+
+      const participantRows = await tx
+        .insert(participants)
+        .values([
+          {
+            conversationId: createdConversation.id,
+            userId: user.id,
+            role: 'member',
+            lastReadAt: now,
+          },
+          {
+            conversationId: createdConversation.id,
+            userId: target.id,
+            role: 'member',
+            lastReadAt: null,
+          },
+        ])
+        .returning()
+
+      const [createdMessage] = await tx
+        .insert(messages)
+        .values({
+          conversationId: createdConversation.id,
+          senderId: user.id,
+          body: input.firstMessage,
+          type: 'text',
+          status: 'sent',
+          attachments: [],
+        })
+        .returning()
+
+      await tx
+        .update(conversations)
+        .set({ updatedAt: now })
+        .where(eq(conversations.id, createdConversation.id))
+
+      return {
+        conversation: createdConversation,
+        participants: participantRows,
+        message: createdMessage,
+      }
+    },
+  )
+
+  return {
+    conversation,
+    participants: insertedParticipants,
+    message,
+    unreadCount: 0,
+  }
+}
+
+export async function getConversationMessages(
+  conversationId: string,
+  user: MinimalUser,
+): Promise<ConversationWithMessages> {
+  const conversation = await loadConversation(conversationId)
+
+  let participant = await findParticipant(conversationId, user.id)
+
+  if (!participant && user.role !== 'admin') {
+    throw new ForbiddenError('You do not have access to this conversation')
+  }
+
+  const messageRecords = await db
+    .select()
+    .from(messages)
+    .where(eq(messages.conversationId, conversationId))
+    .orderBy(asc(messages.createdAt))
+
+  const unreadCount = participant
+    ? await calculateUnreadCount(db, conversationId, user.id, participant.lastReadAt)
+    : 0
+
+  return {
+    conversation,
+    participant,
+    messages: messageRecords,
+    unreadCount,
+  }
+}
+
+export async function addMessageToConversation(
+  conversationId: string,
+  input: MessageCreateInput,
+  user: MinimalUser,
+): Promise<MessageCreationResult> {
+  const conversation = await loadConversation(conversationId)
+
+  let participant = await findParticipant(conversationId, user.id)
+
+  if (!participant && user.role !== 'admin') {
+    throw new ForbiddenError('You do not have access to this conversation')
+  }
+
+  const now = new Date()
+
+  const { message } = await db.transaction(async (tx) => {
+    const [createdMessage] = await tx
+      .insert(messages)
+      .values({
+        conversationId,
+        senderId: user.id,
+        body: input.body,
+        type: 'text',
+        status: 'sent',
+        attachments: [],
+      })
+      .returning()
+
+    await tx
+      .update(conversations)
+      .set({ updatedAt: now })
+      .where(eq(conversations.id, conversationId))
+
+    if (participant) {
+      await tx
+        .update(participants)
+        .set({ lastReadAt: now })
+        .where(
+          and(
+            eq(participants.conversationId, conversationId),
+            eq(participants.userId, user.id),
+          ),
+        )
+
+      participant = { ...participant, lastReadAt: now }
+    }
+
+    return { message: createdMessage }
+  })
+
+  const unreadCount = participant
+    ? await calculateUnreadCount(db, conversationId, user.id, participant.lastReadAt)
+    : 0
+
+  return {
+    conversation,
+    message,
+    unreadCount,
+  }
+}
+
+async function loadConversation(conversationId: string) {
+  const [conversation] = await db
+    .select()
+    .from(conversations)
+    .where(eq(conversations.id, conversationId))
+    .limit(1)
+
+  if (!conversation) {
+    throw new HttpError(404, 'Conversation not found')
+  }
+
+  return conversation
+}
+
+async function findParticipant(conversationId: string, userId: string) {
+  const [participant] = await db
+    .select()
+    .from(participants)
+    .where(and(eq(participants.conversationId, conversationId), eq(participants.userId, userId)))
+    .limit(1)
+
+  return participant ?? null
+}
+
+async function calculateUnreadCount(
+  executor: TransactionLike,
+  conversationId: string,
+  userId: string,
+  lastReadAt: Date | null,
+) {
+  const conditions: SQL[] = [
+    eq(messages.conversationId, conversationId),
+    ne(messages.senderId, userId),
+  ]
+
+  if (lastReadAt) {
+    conditions.push(gt(messages.createdAt, lastReadAt))
+  }
+
+  const whereClause =
+    conditions.length === 1
+      ? conditions[0]
+      : conditions.length > 1
+        ? and(...conditions)
+        : undefined
+
+  const query = executor.select({ count: sql<number>`count(*)` }).from(messages)
+
+  const [result] = whereClause ? await query.where(whereClause) : await query
+
+  return Number(result?.count ?? 0)
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -619,6 +619,7 @@ export const participants = pgTable(
     joinedAt: timestamp("joined_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
+    lastReadAt: timestamp("last_read_at", { withTimezone: true }),
     metadata: jsonb("metadata").default(sql`'{}'::jsonb`).notNull(),
   },
   (table) => ({

--- a/src/app/api/messages/[conversationId]/route.ts
+++ b/src/app/api/messages/[conversationId]/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { HttpError, requireUser } from '@server/auth'
+import {
+  addMessageToConversation,
+  getConversationMessages,
+  messageCreateSchema,
+  serializeConversation,
+  serializeMessage,
+} from '@server/messages'
+
+const RATE_LIMIT_ENDPOINT: Parameters<typeof checkRateLimit>[1] = 'post_message'
+
+const conversationIdSchema = z.string().uuid()
+
+type RouteContext = {
+  params: { conversationId: string }
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const idResult = conversationIdSchema.safeParse(context.params.conversationId)
+
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid conversation id' }, { status: 400 })
+    }
+
+    const user = await requireUser()
+    const result = await getConversationMessages(idResult.data, user)
+
+    return NextResponse.json({
+      conversation: serializeConversation(result.conversation),
+      messages: result.messages.map(serializeMessage),
+      unreadCount: result.unreadCount,
+    })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error('Failed to load messages', error)
+    return NextResponse.json({ error: 'Failed to load messages' }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const idResult = conversationIdSchema.safeParse(context.params.conversationId)
+
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid conversation id' }, { status: 400 })
+    }
+
+    const user = await requireUser()
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000),
+      )
+
+      return NextResponse.json(
+        {
+          error: 'Too many messages. Please try again later.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(retryAfterSeconds) },
+        },
+      )
+    }
+
+    const body = await request.json()
+    const parsed = messageCreateSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const result = await addMessageToConversation(idResult.data, parsed.data, user)
+
+    return NextResponse.json(
+      {
+        message: serializeMessage(result.message),
+        unreadCount: result.unreadCount,
+      },
+      { status: 201 },
+    )
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+    }
+
+    console.error('Failed to send message', error)
+    return NextResponse.json({ error: 'Failed to send message' }, { status: 500 })
+  }
+}

--- a/src/app/api/messages/__tests__/conversation-route.test.ts
+++ b/src/app/api/messages/__tests__/conversation-route.test.ts
@@ -1,0 +1,335 @@
+jest.mock('@server/messages', () => {
+  const actual = jest.requireActual('@server/messages')
+  return {
+    ...actual,
+    getConversationMessages: jest.fn(),
+    addMessageToConversation: jest.fn(),
+    serializeConversation: jest.fn(),
+    serializeMessage: jest.fn(),
+  }
+})
+
+jest.mock('@server/auth', () => {
+  const actual = jest.requireActual('@server/auth')
+  return {
+    ...actual,
+    requireUser: jest.fn(),
+  }
+})
+
+jest.mock('@/lib/rate-limiting', () => ({
+  checkRateLimit: jest.fn(),
+}))
+
+const createRequest = (url: string, init?: { method?: string; body?: unknown; headers?: Record<string, string> }) => {
+  const serializedBody =
+    typeof init?.body === 'string' ? init.body : init?.body !== undefined ? JSON.stringify(init.body) : undefined
+  const headerStore = new Map<string, string>()
+
+  if (init?.headers) {
+    for (const [key, value] of Object.entries(init.headers)) {
+      headerStore.set(key.toLowerCase(), value)
+    }
+  }
+
+  if (serializedBody && !headerStore.has('content-type')) {
+    headerStore.set('content-type', 'application/json')
+  }
+
+  return {
+    url,
+    method: init?.method ?? 'GET',
+    headers: {
+      get(name: string) {
+        return headerStore.get(name.toLowerCase()) ?? null
+      },
+      has(name: string) {
+        return headerStore.has(name.toLowerCase())
+      },
+    },
+    async json() {
+      if (serializedBody === undefined) {
+        throw new Error('No JSON body present')
+      }
+
+      return JSON.parse(serializedBody)
+    },
+  } as unknown as Request
+}
+
+import { GET, POST } from '../[conversationId]/route'
+import { HttpError, UnauthorizedError, requireUser } from '@server/auth'
+import { checkRateLimit } from '@/lib/rate-limiting'
+import {
+  addMessageToConversation,
+  getConversationMessages,
+  serializeConversation,
+  serializeMessage,
+} from '@server/messages'
+
+describe('/api/messages/[conversationId]', () => {
+  const baseUser = {
+    id: '77777777-7777-7777-7777-777777777777',
+    email: 'member@example.com',
+    role: 'member' as const,
+    status: 'active' as const,
+  }
+
+  const conversationId = '88888888-8888-8888-8888-888888888888'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET', () => {
+    it('requires authentication', async () => {
+      ;(requireUser as jest.Mock).mockRejectedValue(new UnauthorizedError())
+
+      const response = await GET(createRequest(`http://localhost/api/messages/${conversationId}`), {
+        params: { conversationId },
+      })
+
+      expect(response.status).toBe(401)
+    })
+
+    it('rejects invalid ids', async () => {
+      ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+
+      const response = await GET(createRequest(`http://localhost/api/messages/not-a-uuid`), {
+        params: { conversationId: 'not-a-uuid' },
+      })
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.error).toBe('Invalid conversation id')
+    })
+
+    it('returns serialized messages when authorized', async () => {
+      ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+
+      const conversation = {
+        id: conversationId,
+        createdBy: baseUser.id,
+        topic: 'General chat',
+        isGroup: false,
+        createdAt: new Date('2024-02-01T12:00:00Z'),
+        updatedAt: new Date('2024-02-01T12:00:00Z'),
+        metadata: {},
+      }
+
+      const message = {
+        id: '99999999-9999-9999-9999-999999999999',
+        conversationId,
+        senderId: baseUser.id,
+        type: 'text',
+        status: 'sent',
+        body: 'Hello!',
+        attachments: [],
+        createdAt: new Date('2024-02-01T12:00:00Z'),
+        updatedAt: new Date('2024-02-01T12:00:00Z'),
+        deliveredAt: null,
+        readAt: null,
+      }
+
+      ;(getConversationMessages as jest.Mock).mockResolvedValue({
+        conversation,
+        messages: [message],
+        participant: null,
+        unreadCount: 0,
+      })
+
+      ;(serializeConversation as jest.Mock).mockReturnValue({
+        id: conversation.id,
+        topic: conversation.topic,
+      })
+
+      ;(serializeMessage as jest.Mock).mockReturnValue({
+        id: message.id,
+        body: message.body,
+      })
+
+      const response = await GET(createRequest(`http://localhost/api/messages/${conversationId}`), {
+        params: { conversationId },
+      })
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({
+        conversation: { id: conversation.id, topic: conversation.topic },
+        messages: [{ id: message.id, body: message.body }],
+        unreadCount: 0,
+      })
+    })
+
+    it('propagates HttpError responses', async () => {
+      ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+      ;(getConversationMessages as jest.Mock).mockRejectedValue(new HttpError(403, 'Forbidden'))
+
+      const response = await GET(createRequest(`http://localhost/api/messages/${conversationId}`), {
+        params: { conversationId },
+      })
+
+      expect(response.status).toBe(403)
+      const payload = await response.json()
+      expect(payload.error).toBe('Forbidden')
+    })
+  })
+
+  describe('POST', () => {
+    it('requires authentication', async () => {
+      ;(requireUser as jest.Mock).mockRejectedValue(new UnauthorizedError())
+
+      const response = await POST(
+        createRequest(`http://localhost/api/messages/${conversationId}`, {
+          method: 'POST',
+          body: { body: 'Hello!' },
+        }),
+        { params: { conversationId } },
+      )
+
+      expect(response.status).toBe(401)
+    })
+
+    it('rejects invalid ids', async () => {
+      ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+
+      const response = await POST(
+        createRequest(`http://localhost/api/messages/not-a-uuid`, {
+          method: 'POST',
+          body: { body: 'Hello!' },
+        }),
+        { params: { conversationId: 'not-a-uuid' } },
+      )
+
+      expect(response.status).toBe(400)
+    })
+
+    it('enforces rate limiting', async () => {
+      ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({
+        allowed: false,
+        remaining: 0,
+        resetTime: new Date('2024-03-01T00:00:00Z'),
+        blocked: false,
+      })
+
+      const response = await POST(
+        createRequest(`http://localhost/api/messages/${conversationId}`, {
+          method: 'POST',
+          body: { body: 'Hello!' },
+        }),
+        { params: { conversationId } },
+      )
+
+      expect(response.status).toBe(429)
+      const payload = await response.json()
+      expect(payload.error).toBe('Too many messages. Please try again later.')
+    })
+
+    it('validates payload', async () => {
+      ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true })
+
+      const response = await POST(
+        createRequest(`http://localhost/api/messages/${conversationId}`, {
+          method: 'POST',
+          body: { body: '' },
+        }),
+        { params: { conversationId } },
+      )
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.error).toBe('Validation failed')
+    })
+
+    it('creates a new message', async () => {
+      ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true })
+
+      const conversation = {
+        id: conversationId,
+        createdBy: baseUser.id,
+        topic: 'General chat',
+        isGroup: false,
+        createdAt: new Date('2024-02-01T12:00:00Z'),
+        updatedAt: new Date('2024-02-01T12:00:00Z'),
+        metadata: {},
+      }
+
+      const message = {
+        id: 'aaaaaaa1-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        conversationId,
+        senderId: baseUser.id,
+        type: 'text',
+        status: 'sent',
+        body: 'Hello!',
+        attachments: [],
+        createdAt: new Date('2024-02-01T12:00:00Z'),
+        updatedAt: new Date('2024-02-01T12:00:00Z'),
+        deliveredAt: null,
+        readAt: null,
+      }
+
+      ;(addMessageToConversation as jest.Mock).mockResolvedValue({
+        conversation,
+        message,
+        unreadCount: 0,
+      })
+
+      ;(serializeMessage as jest.Mock).mockReturnValue({ id: message.id, body: message.body })
+
+      const response = await POST(
+        createRequest(`http://localhost/api/messages/${conversationId}`, {
+          method: 'POST',
+          body: { body: 'Hello!' },
+        }),
+        { params: { conversationId } },
+      )
+
+      expect(response.status).toBe(201)
+      const payload = await response.json()
+      expect(payload).toEqual({
+        message: { id: message.id, body: message.body },
+        unreadCount: 0,
+      })
+
+      expect(addMessageToConversation).toHaveBeenCalledWith(conversationId, { body: 'Hello!' }, baseUser)
+    })
+
+    it('handles HttpErrors from the server module', async () => {
+      ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true })
+      ;(addMessageToConversation as jest.Mock).mockRejectedValue(new HttpError(403, 'Forbidden'))
+
+      const response = await POST(
+        createRequest(`http://localhost/api/messages/${conversationId}`, {
+          method: 'POST',
+          body: { body: 'Hello!' },
+        }),
+        { params: { conversationId } },
+      )
+
+      expect(response.status).toBe(403)
+      const payload = await response.json()
+      expect(payload.error).toBe('Forbidden')
+    })
+
+    it('rejects invalid JSON bodies', async () => {
+      ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true })
+
+      const response = await POST(
+        createRequest(`http://localhost/api/messages/${conversationId}`, {
+          method: 'POST',
+          body: '{',
+        }),
+        { params: { conversationId } },
+      )
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.error).toBe('Invalid JSON payload')
+    })
+  })
+})

--- a/src/app/api/messages/__tests__/start-route.test.ts
+++ b/src/app/api/messages/__tests__/start-route.test.ts
@@ -1,0 +1,238 @@
+jest.mock('@server/messages', () => {
+  const actual = jest.requireActual('@server/messages')
+  return {
+    ...actual,
+    startConversation: jest.fn(),
+    serializeConversation: jest.fn(),
+    serializeMessage: jest.fn(),
+  }
+})
+
+jest.mock('@server/auth', () => {
+  const actual = jest.requireActual('@server/auth')
+  return {
+    ...actual,
+    requireUser: jest.fn(),
+  }
+})
+
+jest.mock('@/lib/rate-limiting', () => ({
+  checkRateLimit: jest.fn(),
+}))
+
+const createRequest = (url: string, init?: { method?: string; body?: unknown; headers?: Record<string, string> }) => {
+  const serializedBody =
+    typeof init?.body === 'string' ? init.body : init?.body !== undefined ? JSON.stringify(init.body) : undefined
+  const headerStore = new Map<string, string>()
+
+  if (init?.headers) {
+    for (const [key, value] of Object.entries(init.headers)) {
+      headerStore.set(key.toLowerCase(), value)
+    }
+  }
+
+  if (serializedBody && !headerStore.has('content-type')) {
+    headerStore.set('content-type', 'application/json')
+  }
+
+  return {
+    url,
+    method: init?.method ?? 'POST',
+    headers: {
+      get(name: string) {
+        return headerStore.get(name.toLowerCase()) ?? null
+      },
+      has(name: string) {
+        return headerStore.has(name.toLowerCase())
+      },
+    },
+    async json() {
+      if (serializedBody === undefined) {
+        throw new Error('No JSON body present')
+      }
+
+      return JSON.parse(serializedBody)
+    },
+  } as unknown as Request
+}
+
+import { POST as startConversationRoute } from '../start/route'
+import { HttpError, UnauthorizedError, requireUser } from '@server/auth'
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { startConversation, serializeConversation, serializeMessage } from '@server/messages'
+
+describe('POST /api/messages/start', () => {
+  const baseUser = {
+    id: '11111111-1111-1111-1111-111111111111',
+    email: 'initiator@example.com',
+    role: 'member' as const,
+    status: 'active' as const,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('requires authentication', async () => {
+    ;(requireUser as jest.Mock).mockRejectedValue(new UnauthorizedError())
+
+    const response = await startConversationRoute(
+      createRequest('http://localhost/api/messages/start', {
+        method: 'POST',
+        body: {},
+      }),
+    )
+
+    expect(response.status).toBe(401)
+  })
+
+  it('enforces rate limiting', async () => {
+    ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+    ;(checkRateLimit as jest.Mock).mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetTime: new Date('2024-01-01T00:00:00Z'),
+      blocked: false,
+    })
+
+    const response = await startConversationRoute(
+      createRequest('http://localhost/api/messages/start', {
+        body: {
+          targetUserId: '22222222-2222-2222-2222-222222222222',
+          firstMessage: 'Hello there',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(429)
+    const payload = await response.json()
+    expect(payload.error).toBe('Too many messages. Please try again later.')
+  })
+
+  it('rejects invalid payloads', async () => {
+    ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+    ;(checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true })
+
+    const response = await startConversationRoute(
+      createRequest('http://localhost/api/messages/start', {
+        body: {
+          targetUserId: 'not-a-uuid',
+          firstMessage: '',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+    expect(payload.error).toBe('Validation failed')
+  })
+
+  it('creates a conversation and returns serialized data', async () => {
+    ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+    ;(checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true })
+
+    const conversation = {
+      id: '33333333-3333-3333-3333-333333333333',
+      createdBy: baseUser.id,
+      topic: 'Inquiry about listing',
+      isGroup: false,
+      createdAt: new Date('2024-01-02T10:00:00Z'),
+      updatedAt: new Date('2024-01-02T10:00:00Z'),
+      metadata: {},
+    }
+
+    const message = {
+      id: '44444444-4444-4444-4444-444444444444',
+      conversationId: conversation.id,
+      senderId: baseUser.id,
+      type: 'text',
+      status: 'sent',
+      body: 'Hello there',
+      attachments: [],
+      createdAt: new Date('2024-01-02T10:00:00Z'),
+      updatedAt: new Date('2024-01-02T10:00:00Z'),
+      deliveredAt: null,
+      readAt: null,
+    }
+
+    ;(startConversation as jest.Mock).mockResolvedValue({
+      conversation,
+      participants: [],
+      message,
+      unreadCount: 0,
+    })
+
+    ;(serializeConversation as jest.Mock).mockReturnValue({
+      id: conversation.id,
+      topic: conversation.topic,
+    })
+
+    ;(serializeMessage as jest.Mock).mockReturnValue({
+      id: message.id,
+      body: message.body,
+    })
+
+    const response = await startConversationRoute(
+      createRequest('http://localhost/api/messages/start', {
+        body: {
+          targetUserId: '22222222-2222-2222-2222-222222222222',
+          subject: 'Inquiry about listing',
+          context: { type: 'classified', entityId: '55555555-5555-5555-5555-555555555555' },
+          firstMessage: 'Hello there',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(201)
+    const payload = await response.json()
+    expect(payload).toEqual({
+      conversation: { id: conversation.id, topic: conversation.topic },
+      message: { id: message.id, body: message.body },
+      unreadCount: 0,
+    })
+
+    expect(startConversation).toHaveBeenCalledWith(
+      {
+        targetUserId: '22222222-2222-2222-2222-222222222222',
+        subject: 'Inquiry about listing',
+        context: { type: 'classified', entityId: '55555555-5555-5555-5555-555555555555' },
+        firstMessage: 'Hello there',
+      },
+      baseUser,
+    )
+  })
+
+  it('handles server errors gracefully', async () => {
+    ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+    ;(checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true })
+    ;(startConversation as jest.Mock).mockRejectedValue(new HttpError(404, 'Target user not found'))
+
+    const response = await startConversationRoute(
+      createRequest('http://localhost/api/messages/start', {
+        body: {
+          targetUserId: '22222222-2222-2222-2222-222222222222',
+          firstMessage: 'Hello there',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(404)
+    const payload = await response.json()
+    expect(payload.error).toBe('Target user not found')
+  })
+
+  it('rejects invalid JSON payloads', async () => {
+    ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+    ;(checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true })
+
+    const response = await startConversationRoute(
+      createRequest('http://localhost/api/messages/start', {
+        body: '{',
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+    expect(payload.error).toBe('Invalid JSON payload')
+  })
+})

--- a/src/app/api/messages/start/route.ts
+++ b/src/app/api/messages/start/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { HttpError, requireUser } from '@server/auth'
+import {
+  serializeConversation,
+  serializeMessage,
+  startConversation,
+  startConversationSchema,
+} from '@server/messages'
+
+const RATE_LIMIT_ENDPOINT: Parameters<typeof checkRateLimit>[1] = 'post_message'
+
+export async function POST(request: Request) {
+  try {
+    const user = await requireUser()
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000),
+      )
+
+      return NextResponse.json(
+        {
+          error: 'Too many messages. Please try again later.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(retryAfterSeconds) },
+        },
+      )
+    }
+
+    const body = await request.json()
+    const parsed = startConversationSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const result = await startConversation(parsed.data, user)
+
+    return NextResponse.json(
+      {
+        conversation: serializeConversation(result.conversation),
+        message: serializeMessage(result.message),
+        unreadCount: result.unreadCount,
+      },
+      { status: 201 },
+    )
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+    }
+
+    console.error('Failed to start conversation', error)
+    return NextResponse.json(
+      { error: 'Failed to start conversation' },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add lastReadAt tracking to conversation participants
- implement server-side messaging helpers for starting conversations, posting messages, and computing unread counts
- expose /api/messages/start and /api/messages/[conversationId] routes with validation, rate limiting, and test coverage

## Testing
- `npm run test -- --runTestsByPath src/app/api/messages/__tests__/start-route.test.ts src/app/api/messages/__tests__/conversation-route.test.ts`
- `npm run type-check -- --pretty false` *(fails: project has numerous existing schema/type gaps unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7658d31c832b91186e093948fed2