### PR TITLE
Add member report submission endpoint

### DIFF
--- a/drizzle/0002_update_reports_table.sql
+++ b/drizzle/0002_update_reports_table.sql
@@ -1,0 +1,18 @@
+ALTER TABLE "reports" RENAME COLUMN "subject_type" TO "target_type";
+ALTER TABLE "reports" RENAME COLUMN "subject_id" TO "target_id";
+
+ALTER TABLE "reports" ALTER COLUMN "status" SET DEFAULT 'open';
+
+ALTER TABLE "reports" DROP CONSTRAINT IF EXISTS "reports_subject_check";
+ALTER TABLE "reports" ADD CONSTRAINT "reports_target_check" CHECK (
+  "target_type" IN ('user', 'business', 'event', 'announcement', 'classified', 'message')
+);
+
+ALTER INDEX IF EXISTS "reports_subject_idx" RENAME TO "reports_target_idx";
+
+ALTER TABLE "reports" DROP CONSTRAINT IF EXISTS "reports_status_check";
+ALTER TABLE "reports" ADD CONSTRAINT "reports_status_check" CHECK (
+  "status" IN ('open', 'pending', 'reviewing', 'resolved', 'dismissed')
+);
+
+UPDATE "reports" SET "status" = 'open' WHERE "status" = 'pending';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1758205076012,
       "tag": "0001_add_event_category",
       "breakpoints": false
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1758205077012,
+      "tag": "0002_update_reports_table",
+      "breakpoints": false
     }
   ]
 }

--- a/server/reports.ts
+++ b/server/reports.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod'
+
+import {
+  db,
+  reports,
+  reportTargetTypes,
+  type Report,
+} from '@/lib/db'
+import { HttpError } from '@server/auth'
+
+const MAX_REASON_LENGTH = 64
+const MIN_REASON_LENGTH = 3
+const MAX_DETAILS_LENGTH = 2000
+
+export const reportCreateSchema = z
+  .object({
+    targetType: z.enum(reportTargetTypes),
+    targetId: z.string().uuid(),
+    reason: z
+      .string()
+      .trim()
+      .min(MIN_REASON_LENGTH, 'Please provide a reason for the report')
+      .max(
+        MAX_REASON_LENGTH,
+        `Reason must be ${MAX_REASON_LENGTH} characters or fewer`,
+      ),
+    details: z
+      .string()
+      .trim()
+      .min(1, 'Additional details cannot be empty')
+      .max(
+        MAX_DETAILS_LENGTH,
+        `Details must be ${MAX_DETAILS_LENGTH} characters or fewer`,
+      )
+      .optional(),
+  })
+  .strict()
+
+export type ReportCreateInput = z.infer<typeof reportCreateSchema>
+
+export type ReportCreateParams = ReportCreateInput & {
+  reporterId: string
+}
+
+export type SerializedReport = ReturnType<typeof serializeReport>
+
+export function serializeReport(report: Report) {
+  return {
+    id: report.id,
+    reporterId: report.reporterId,
+    targetType: report.targetType,
+    targetId: report.targetId,
+    reason: report.reason,
+    status: report.status,
+    details: report.details ?? null,
+    createdAt: report.createdAt.toISOString(),
+    updatedAt: report.updatedAt.toISOString(),
+  }
+}
+
+export async function createReport(params: ReportCreateParams) {
+  const now = new Date()
+
+  const [created] = await db
+    .insert(reports)
+    .values({
+      reporterId: params.reporterId,
+      targetType: params.targetType,
+      targetId: params.targetId,
+      reason: params.reason,
+      status: 'open',
+      ...(params.details ? { details: params.details } : {}),
+      updatedAt: now,
+    })
+    .returning()
+
+  if (!created) {
+    throw new HttpError(500, 'Failed to persist report')
+  }
+
+  return created
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -69,7 +69,7 @@ export type MessageType = (typeof messageTypes)[number];
 export const messageStatuses = ["sent", "delivered", "read"] as const;
 export type MessageStatus = (typeof messageStatuses)[number];
 
-export const reportSubjects = [
+export const reportTargetTypes = [
   "user",
   "business",
   "event",
@@ -77,9 +77,15 @@ export const reportSubjects = [
   "classified",
   "message",
 ] as const;
-export type ReportSubject = (typeof reportSubjects)[number];
+export type ReportTargetType = (typeof reportTargetTypes)[number];
 
-export const reportStatuses = ["pending", "reviewing", "resolved", "dismissed"] as const;
+export const reportStatuses = [
+  "open",
+  "pending",
+  "reviewing",
+  "resolved",
+  "dismissed",
+] as const;
 export type ReportStatus = (typeof reportStatuses)[number];
 
 export const subscriptionStatuses = [
@@ -688,14 +694,14 @@ export const reports = pgTable(
     reporterId: uuid("reporter_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
-    subjectType: varchar("subject_type", { length: 32 })
+    targetType: varchar("target_type", { length: 32 })
       .notNull()
-      .$type<ReportSubject>(),
-    subjectId: uuid("subject_id").notNull(),
+      .$type<ReportTargetType>(),
+    targetId: uuid("target_id").notNull(),
     reason: varchar("reason", { length: 64 }).notNull(),
     status: varchar("status", { length: 32 })
       .notNull()
-      .default("pending")
+      .default("open")
       .$type<ReportStatus>(),
     details: text("details"),
     resolution: text("resolution"),
@@ -709,18 +715,18 @@ export const reports = pgTable(
   },
   (table) => ({
     reportsReporterIdx: index("reports_reporter_idx").on(table.reporterId),
-    reportsSubjectIdx: index("reports_subject_idx").on(
-      table.subjectType,
-      table.subjectId,
+    reportsTargetIdx: index("reports_target_idx").on(
+      table.targetType,
+      table.targetId,
     ),
     reportsStatusIdx: index("reports_status_idx").on(table.status),
-    reportsSubjectCheck: check(
-      "reports_subject_check",
-      sql`${table.subjectType} in ('user', 'business', 'event', 'announcement', 'classified', 'message')`,
+    reportsTargetCheck: check(
+      "reports_target_check",
+      sql`${table.targetType} in ('user', 'business', 'event', 'announcement', 'classified', 'message')`,
     ),
     reportsStatusCheck: check(
       "reports_status_check",
-      sql`${table.status} in ('pending', 'reviewing', 'resolved', 'dismissed')`,
+      sql`${table.status} in ('open', 'pending', 'reviewing', 'resolved', 'dismissed')`,
     ),
   }),
 );

--- a/src/app/api/report/__tests__/route.test.ts
+++ b/src/app/api/report/__tests__/route.test.ts
@@ -1,0 +1,221 @@
+jest.mock('@server/reports', () => {
+  const actual = jest.requireActual('@server/reports')
+  return {
+    ...actual,
+    createReport: jest.fn(),
+  }
+})
+
+jest.mock('@server/auth', () => {
+  const actual = jest.requireActual('@server/auth')
+  return {
+    ...actual,
+    requireUser: jest.fn(),
+  }
+})
+
+jest.mock('@/lib/rate-limiting', () => ({
+  checkRateLimit: jest.fn(),
+}))
+
+const createRequest = (
+  url: string,
+  init?: { method?: string; body?: unknown; headers?: Record<string, string> },
+) => {
+  const serializedBody =
+    typeof init?.body === 'string'
+      ? init.body
+      : init?.body !== undefined
+      ? JSON.stringify(init.body)
+      : undefined
+  const headerStore = new Map<string, string>()
+
+  if (init?.headers) {
+    for (const [key, value] of Object.entries(init.headers)) {
+      headerStore.set(key.toLowerCase(), value)
+    }
+  }
+
+  if (serializedBody && !headerStore.has('content-type')) {
+    headerStore.set('content-type', 'application/json')
+  }
+
+  return {
+    url,
+    method: init?.method ?? 'POST',
+    headers: {
+      get(name: string) {
+        return headerStore.get(name.toLowerCase()) ?? null
+      },
+      has(name: string) {
+        return headerStore.has(name.toLowerCase())
+      },
+    },
+    async json() {
+      if (!serializedBody) {
+        throw new Error('No JSON body present')
+      }
+      return JSON.parse(serializedBody)
+    },
+    async text() {
+      return serializedBody ?? ''
+    },
+  } as unknown as Request
+}
+
+import { POST as createReportRoute } from '../route'
+import { createReport } from '@server/reports'
+import { requireUser, UnauthorizedError } from '@server/auth'
+import { checkRateLimit } from '@/lib/rate-limiting'
+
+describe('POST /api/report', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('requires authentication', async () => {
+    ;(requireUser as jest.Mock).mockRejectedValue(new UnauthorizedError())
+
+    const response = await createReportRoute(
+      createRequest('http://localhost/api/report', {
+        method: 'POST',
+        body: {
+          targetType: 'user',
+          targetId: '00000000-0000-0000-0000-000000000111',
+          reason: 'spam',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(401)
+  })
+
+  it('enforces rate limiting', async () => {
+    const user = {
+      id: 'user-123',
+      role: 'member',
+      email: 'member@example.com',
+      status: 'active',
+    }
+    ;(requireUser as jest.Mock).mockResolvedValue(user)
+
+    const resetTime = new Date('2024-07-11T10:00:00Z')
+    ;(checkRateLimit as jest.Mock).mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetTime,
+      blocked: false,
+    })
+
+    const response = await createReportRoute(
+      createRequest('http://localhost/api/report', {
+        method: 'POST',
+        body: {
+          targetType: 'user',
+          targetId: '00000000-0000-0000-0000-000000000222',
+          reason: 'spam content',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(429)
+    const payload = await response.json()
+    expect(payload.retryAfter).toBe(resetTime.toISOString())
+  })
+
+  it('validates the incoming payload', async () => {
+    const user = {
+      id: 'user-456',
+      role: 'member',
+      email: 'member@example.com',
+      status: 'active',
+    }
+    ;(requireUser as jest.Mock).mockResolvedValue(user)
+    ;(checkRateLimit as jest.Mock).mockResolvedValue({
+      allowed: true,
+      remaining: 9,
+      resetTime: new Date('2024-07-11T10:00:00Z'),
+      blocked: false,
+    })
+
+    const response = await createReportRoute(
+      createRequest('http://localhost/api/report', {
+        method: 'POST',
+        body: {
+          targetType: 'user',
+          targetId: '00000000-0000-0000-0000-000000000333',
+          reason: 'no',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+    expect(payload.error).toBe('Validation failed')
+  })
+
+  it('creates a report when validation passes', async () => {
+    const user = {
+      id: 'user-789',
+      role: 'member',
+      email: 'member@example.com',
+      status: 'active',
+    }
+    ;(requireUser as jest.Mock).mockResolvedValue(user)
+    ;(checkRateLimit as jest.Mock).mockResolvedValue({
+      allowed: true,
+      remaining: 8,
+      resetTime: new Date('2024-07-11T10:10:00Z'),
+      blocked: false,
+    })
+
+    const createdAt = new Date('2024-07-01T12:00:00Z')
+    const updatedAt = new Date('2024-07-01T12:00:00Z')
+
+    ;(createReport as jest.Mock).mockResolvedValue({
+      id: '00000000-0000-0000-0000-000000000444',
+      reporterId: user.id,
+      targetType: 'user',
+      targetId: '00000000-0000-0000-0000-000000000555',
+      reason: 'harassment',
+      status: 'open',
+      details: null,
+      resolution: null,
+      createdAt,
+      updatedAt,
+      metadata: {},
+    })
+
+    const response = await createReportRoute(
+      createRequest('http://localhost/api/report', {
+        method: 'POST',
+        body: {
+          targetType: 'user',
+          targetId: '00000000-0000-0000-0000-000000000555',
+          reason: 'harassment',
+        },
+      }),
+    )
+
+    expect(createReport).toHaveBeenCalledWith({
+      targetType: 'user',
+      targetId: '00000000-0000-0000-0000-000000000555',
+      reason: 'harassment',
+      reporterId: user.id,
+    })
+
+    expect(response.status).toBe(201)
+    const payload = await response.json()
+    expect(payload.report).toEqual({
+      id: '00000000-0000-0000-0000-000000000444',
+      reporterId: user.id,
+      targetType: 'user',
+      targetId: '00000000-0000-0000-0000-000000000555',
+      reason: 'harassment',
+      status: 'open',
+      details: null,
+      createdAt: createdAt.toISOString(),
+      updatedAt: updatedAt.toISOString(),
+    })
+  })
+})

--- a/src/app/api/report/route.ts
+++ b/src/app/api/report/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { HttpError, requireUser } from '@server/auth'
+import {
+  createReport,
+  reportCreateSchema,
+  serializeReport,
+} from '@server/reports'
+
+const RATE_LIMIT_ENDPOINT: Parameters<typeof checkRateLimit>[1] = 'report_submit'
+
+// TODO: Surface submitted reports in the /admin moderation queue.
+export async function POST(request: Request) {
+  try {
+    const user = await requireUser()
+
+    const rateLimit = await checkRateLimit(user.id, RATE_LIMIT_ENDPOINT)
+    if (!rateLimit.allowed) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000),
+      )
+
+      return NextResponse.json(
+        {
+          error: 'Too many reports submitted. Please try again later.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(retryAfterSeconds) },
+        },
+      )
+    }
+
+    const body = await request.json()
+    const parsed = reportCreateSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const report = await createReport({
+      ...parsed.data,
+      reporterId: user.id,
+    })
+
+    return NextResponse.json(
+      { report: serializeReport(report) },
+      { status: 201 },
+    )
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: 'Invalid JSON payload' },
+        { status: 400 },
+      )
+    }
+
+    console.error('Failed to submit report', error)
+    return NextResponse.json(
+      { error: 'Failed to submit report' },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- align the reports schema with target-based naming and ensure new reports default to an open status
- add strongly typed helpers for creating and serialising reports plus a rate-limited POST /api/report route for members
- cover the new endpoint with Jest tests and include a migration to update existing databases

## Testing
- `npm run test -- --runTestsByPath src/app/api/report/__tests__/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68cc98f280b8832ba58f11ab63d1418c