### PR TITLE
feat: add admin overview and search API endpoints

### DIFF
--- a/server/admin.ts
+++ b/server/admin.ts
@@ -1,0 +1,166 @@
+import { and, desc, eq, gte, gt, ilike, isNull, ne, or, sql } from 'drizzle-orm'
+
+import {
+  businesses,
+  classifieds,
+  db,
+  events,
+  profiles,
+  reports,
+  users,
+} from '@/lib/db'
+
+const COUNT_COLUMN = sql<number>`cast(count(*) as integer)`
+
+const extractCount = (rows: Array<{ count: number }>): number => {
+  if (!rows.length) {
+    return 0
+  }
+
+  const value = Number(rows[0]?.count ?? 0)
+  return Number.isFinite(value) ? value : 0
+}
+
+export type AdminOverview = {
+  users: number
+  businesses: {
+    verified: number
+    unverified: number
+  }
+  events: {
+    upcoming: number
+  }
+  classifieds: {
+    active: number
+  }
+  reports: {
+    open: number
+  }
+}
+
+export async function getAdminOverview(): Promise<AdminOverview> {
+  const now = new Date()
+
+  const [userRows, verifiedBusinessRows, unverifiedBusinessRows, upcomingEventRows, activeClassifiedRows, openReportRows] =
+    await Promise.all([
+      db.select({ count: COUNT_COLUMN }).from(users),
+      db.select({ count: COUNT_COLUMN }).from(businesses).where(eq(businesses.status, 'published')),
+      db.select({ count: COUNT_COLUMN }).from(businesses).where(ne(businesses.status, 'published')),
+      db
+        .select({ count: COUNT_COLUMN })
+        .from(events)
+        .where(and(eq(events.status, 'published'), gte(events.startAt, now))),
+      db
+        .select({ count: COUNT_COLUMN })
+        .from(classifieds)
+        .where(
+          and(
+            eq(classifieds.status, 'published'),
+            or(isNull(classifieds.expiresAt), gt(classifieds.expiresAt, now)),
+          ),
+        ),
+      db.select({ count: COUNT_COLUMN }).from(reports).where(eq(reports.status, 'open')),
+    ])
+
+  return {
+    users: extractCount(userRows),
+    businesses: {
+      verified: extractCount(verifiedBusinessRows),
+      unverified: extractCount(unverifiedBusinessRows),
+    },
+    events: {
+      upcoming: extractCount(upcomingEventRows),
+    },
+    classifieds: {
+      active: extractCount(activeClassifiedRows),
+    },
+    reports: {
+      open: extractCount(openReportRows),
+    },
+  }
+}
+
+const MAX_SEARCH_RESULTS = 25
+
+const escapeLikePattern = (value: string) => value.replace(/[%_]/g, '\\$&')
+
+export type AdminSearchResults = {
+  users: Array<{
+    id: string
+    email: string
+    role: string
+    status: string
+    displayName: string | null
+    createdAt: Date
+  }>
+  businesses: Array<{
+    id: string
+    name: string
+    email: string | null
+    status: string
+    plan: string
+    verified: boolean
+    createdAt: Date
+  }>
+}
+
+export async function searchAdminDirectory(query: string, options: { limit?: number } = {}): Promise<AdminSearchResults> {
+  const trimmed = query.trim()
+
+  if (trimmed.length === 0) {
+    return { users: [], businesses: [] }
+  }
+
+  const limit = Math.max(1, Math.min(MAX_SEARCH_RESULTS, options.limit ?? MAX_SEARCH_RESULTS))
+  const pattern = `%${escapeLikePattern(trimmed)}%`
+
+  const [userRows, businessRows] = await Promise.all([
+    db
+      .select({
+        id: users.id,
+        email: users.email,
+        role: users.role,
+        status: users.status,
+        createdAt: users.createdAt,
+        displayName: profiles.displayName,
+      })
+      .from(users)
+      .leftJoin(profiles, eq(profiles.userId, users.id))
+      .where(or(ilike(users.email, pattern), ilike(profiles.displayName, pattern)))
+      .orderBy(desc(users.createdAt))
+      .limit(limit),
+    db
+      .select({
+        id: businesses.id,
+        name: businesses.name,
+        email: businesses.email,
+        status: businesses.status,
+        plan: businesses.plan,
+        createdAt: businesses.createdAt,
+      })
+      .from(businesses)
+      .where(or(ilike(businesses.name, pattern), ilike(businesses.email, pattern)))
+      .orderBy(desc(businesses.createdAt))
+      .limit(limit),
+  ])
+
+  return {
+    users: userRows.map((row) => ({
+      id: row.id,
+      email: row.email,
+      role: row.role,
+      status: row.status,
+      displayName: row.displayName ?? null,
+      createdAt: row.createdAt,
+    })),
+    businesses: businessRows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      email: row.email,
+      status: row.status,
+      plan: row.plan,
+      verified: row.status === 'published',
+      createdAt: row.createdAt,
+    })),
+  }
+}

--- a/src/app/api/admin/__tests__/routes.test.ts
+++ b/src/app/api/admin/__tests__/routes.test.ts
@@ -1,0 +1,170 @@
+jest.mock('@server/admin', () => {
+  const actual = jest.requireActual('@server/admin')
+  return {
+    ...actual,
+    getAdminOverview: jest.fn(),
+    searchAdminDirectory: jest.fn(),
+  }
+})
+
+jest.mock('@server/auth', () => {
+  const actual = jest.requireActual('@server/auth')
+  return {
+    ...actual,
+    requireUser: jest.fn(),
+  }
+})
+
+import { GET as overviewGet } from '../overview/route'
+import { GET as searchGet } from '../search/route'
+import { getAdminOverview, searchAdminDirectory } from '@server/admin'
+import { requireUser, UnauthorizedError } from '@server/auth'
+
+const createRequest = (url: string) => new Request(url)
+
+describe('Admin API routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET /api/admin/overview', () => {
+    it('returns overview metrics for admin users', async () => {
+      const adminUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(adminUser)
+      const overview = {
+        users: 42,
+        businesses: { verified: 10, unverified: 5 },
+        events: { upcoming: 3 },
+        classifieds: { active: 7 },
+        reports: { open: 4 },
+      }
+      ;(getAdminOverview as jest.Mock).mockResolvedValue(overview)
+
+      const response = await overviewGet()
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({ overview })
+      expect(requireUser).toHaveBeenCalledTimes(1)
+      expect(getAdminOverview).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects non-admin users with 403', async () => {
+      const memberUser = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(memberUser)
+
+      const response = await overviewGet()
+
+      expect(response.status).toBe(403)
+      const payload = await response.json()
+      expect(payload.error).toBe('Forbidden')
+      expect(getAdminOverview).not.toHaveBeenCalled()
+    })
+
+    it('requires authentication', async () => {
+      ;(requireUser as jest.Mock).mockRejectedValue(new UnauthorizedError())
+
+      const response = await overviewGet()
+
+      expect(response.status).toBe(401)
+      const payload = await response.json()
+      expect(payload.error).toBe('Authentication required')
+    })
+  })
+
+  describe('GET /api/admin/search', () => {
+    it('runs search for admin users', async () => {
+      const adminUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(adminUser)
+      const results = {
+        users: [
+          {
+            id: 'user-1',
+            email: 'amina@example.com',
+            role: 'admin',
+            status: 'active',
+            displayName: 'Amina',
+            createdAt: new Date('2024-01-01T00:00:00Z'),
+          },
+        ],
+        businesses: [
+          {
+            id: 'biz-1',
+            name: 'Sunrise Catering',
+            email: 'orders@example.com',
+            status: 'published',
+            plan: 'premium',
+            verified: true,
+            createdAt: new Date('2024-01-05T00:00:00Z'),
+          },
+        ],
+      }
+      ;(searchAdminDirectory as jest.Mock).mockResolvedValue(results)
+
+      const response = await searchGet(createRequest('http://localhost/api/admin/search?q=%20amina%20'))
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({
+        results: {
+          users: [
+            {
+              id: 'user-1',
+              email: 'amina@example.com',
+              role: 'admin',
+              status: 'active',
+              displayName: 'Amina',
+              createdAt: results.users[0]!.createdAt.toISOString(),
+            },
+          ],
+          businesses: [
+            {
+              id: 'biz-1',
+              name: 'Sunrise Catering',
+              email: 'orders@example.com',
+              status: 'published',
+              plan: 'premium',
+              verified: true,
+              createdAt: results.businesses[0]!.createdAt.toISOString(),
+            },
+          ],
+        },
+      })
+      expect(searchAdminDirectory).toHaveBeenCalledWith('amina')
+    })
+
+    it('rejects non-admin users', async () => {
+      const memberUser = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(memberUser)
+
+      const response = await searchGet(createRequest('http://localhost/api/admin/search?q=amina'))
+
+      expect(response.status).toBe(403)
+      const payload = await response.json()
+      expect(payload.error).toBe('Forbidden')
+      expect(searchAdminDirectory).not.toHaveBeenCalled()
+    })
+
+    it('validates query parameters', async () => {
+      const adminUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(adminUser)
+
+      const response = await searchGet(createRequest('http://localhost/api/admin/search?q=a'))
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.error).toBe('Invalid query parameters')
+      expect(searchAdminDirectory).not.toHaveBeenCalled()
+    })
+
+    it('requires authentication', async () => {
+      ;(requireUser as jest.Mock).mockRejectedValue(new UnauthorizedError())
+
+      const response = await searchGet(createRequest('http://localhost/api/admin/search?q=amina'))
+
+      expect(response.status).toBe(401)
+      const payload = await response.json()
+      expect(payload.error).toBe('Authentication required')
+    })
+  })
+})

--- a/src/app/api/admin/overview/route.ts
+++ b/src/app/api/admin/overview/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+
+import { HttpError, requireUser } from '@server/auth'
+import { getAdminOverview } from '@server/admin'
+
+export async function GET() {
+  try {
+    const user = await requireUser()
+
+    if (user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const overview = await getAdminOverview()
+
+    return NextResponse.json({ overview })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error('Failed to load admin overview', error)
+    return NextResponse.json({ error: 'Failed to load admin overview' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/search/route.ts
+++ b/src/app/api/admin/search/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { HttpError, requireUser } from '@server/auth'
+import { searchAdminDirectory } from '@server/admin'
+
+const querySchema = z.object({
+  q: z.string().trim().min(2).max(255),
+})
+
+export async function GET(request: Request) {
+  try {
+    const user = await requireUser()
+
+    if (user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const parsed = querySchema.safeParse({ q: searchParams.get('q') })
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid query parameters',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const results = await searchAdminDirectory(parsed.data.q)
+
+    return NextResponse.json({ results })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    console.error('Failed to run admin search', error)
+    return NextResponse.json({ error: 'Failed to run admin search' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add admin data utilities to aggregate overview metrics and perform admin search queries
- expose admin-only overview and search API routes guarded by role checks and query validation
- cover the new endpoints with Jest tests for access control and validation paths

## Testing
- npm test -- src/app/api/admin/__tests__/routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cce5c9a6c4832ba19f47556c8b9a30