### PR TITLE
Add subscription-based write quotas and usage tracking

### DIFF
--- a/server/usage.ts
+++ b/server/usage.ts
@@ -1,0 +1,187 @@
+import { and, desc, eq, inArray } from 'drizzle-orm'
+
+import { db, subscriptions, usage, type SubscriptionPlan, type SubscriptionStatus } from '@/lib/db'
+
+export type UsagePeriod = 'day' | 'month'
+export type UsageKind = 'classifieds' | 'announcements' | 'messages'
+
+type UsageQuota = {
+  period: UsagePeriod
+  limit: number | null
+}
+
+type UsageConfig = {
+  feature: string
+  action: string
+  period: UsagePeriod
+  limits: Record<SubscriptionPlan, number | null>
+}
+
+const ACTIVE_SUBSCRIPTION_STATUSES: SubscriptionStatus[] = ['active', 'trialing']
+
+const USAGE_CONFIG: Record<UsageKind, UsageConfig> = {
+  classifieds: {
+    feature: 'classifieds',
+    action: 'create',
+    period: 'month',
+    limits: {
+      free: 2,
+      plus: null,
+      family: null,
+    },
+  },
+  announcements: {
+    feature: 'announcements',
+    action: 'create',
+    period: 'month',
+    limits: {
+      free: 1,
+      plus: null,
+      family: null,
+    },
+  },
+  messages: {
+    feature: 'messages',
+    action: 'send',
+    period: 'day',
+    limits: {
+      free: 200,
+      plus: null,
+      family: null,
+    },
+  },
+}
+
+const DEFAULT_SUBSCRIPTION_TIER: SubscriptionPlan = 'free'
+
+const startOfDayUtc = (reference: Date) => {
+  const start = new Date(reference)
+  start.setUTCHours(0, 0, 0, 0)
+  return start
+}
+
+const startOfMonthUtc = (reference: Date) => {
+  const start = new Date(reference)
+  start.setUTCDate(1)
+  start.setUTCHours(0, 0, 0, 0)
+  return start
+}
+
+const resolveWindowBounds = (period: UsagePeriod, reference = new Date()) => {
+  if (period === 'day') {
+    const windowStart = startOfDayUtc(reference)
+    const windowEnd = new Date(windowStart)
+    windowEnd.setUTCDate(windowEnd.getUTCDate() + 1)
+    return { windowStart, windowEnd }
+  }
+
+  const windowStart = startOfMonthUtc(reference)
+  const windowEnd = new Date(windowStart)
+  windowEnd.setUTCMonth(windowEnd.getUTCMonth() + 1)
+  return { windowStart, windowEnd }
+}
+
+const getUsageConfig = (kind: UsageKind): UsageConfig => {
+  return USAGE_CONFIG[kind]
+}
+
+export function checkQuota(tier: SubscriptionPlan, kind: UsageKind): UsageQuota {
+  const config = getUsageConfig(kind)
+  return {
+    period: config.period,
+    limit: config.limits[tier] ?? null,
+  }
+}
+
+export async function getUserSubscriptionTier(userId: string): Promise<SubscriptionPlan> {
+  const [subscription] = await db
+    .select({ plan: subscriptions.plan })
+    .from(subscriptions)
+    .where(
+      and(
+        eq(subscriptions.userId, userId),
+        inArray(subscriptions.status, ACTIVE_SUBSCRIPTION_STATUSES),
+      ),
+    )
+    .orderBy(desc(subscriptions.currentPeriodEnd))
+    .limit(1)
+
+  return subscription?.plan ?? DEFAULT_SUBSCRIPTION_TIER
+}
+
+export async function getUsageCount(
+  userId: string,
+  period: UsagePeriod,
+  kind: UsageKind,
+): Promise<number> {
+  const config = getUsageConfig(kind)
+  const { windowStart } = resolveWindowBounds(period)
+
+  const [record] = await db
+    .select({ count: usage.count })
+    .from(usage)
+    .where(
+      and(
+        eq(usage.scope, 'user'),
+        eq(usage.userId, userId),
+        eq(usage.feature, config.feature),
+        eq(usage.action, config.action),
+        eq(usage.windowStart, windowStart),
+      ),
+    )
+    .limit(1)
+
+  return record?.count ?? 0
+}
+
+export async function incrementUsage(
+  userId: string,
+  period: UsagePeriod,
+  kind: UsageKind,
+): Promise<number> {
+  const config = getUsageConfig(kind)
+  const { windowStart, windowEnd } = resolveWindowBounds(period)
+
+  return db.transaction(async (tx) => {
+    const existing = await tx
+      .select({ id: usage.id, count: usage.count })
+      .from(usage)
+      .where(
+        and(
+          eq(usage.scope, 'user'),
+          eq(usage.userId, userId),
+          eq(usage.feature, config.feature),
+          eq(usage.action, config.action),
+          eq(usage.windowStart, windowStart),
+        ),
+      )
+      .limit(1)
+
+    if (existing.length > 0) {
+      const nextCount = existing[0].count + 1
+
+      await tx
+        .update(usage)
+        .set({ count: nextCount, windowEnd })
+        .where(eq(usage.id, existing[0].id))
+
+      return nextCount
+    }
+
+    const [inserted] = await tx
+      .insert(usage)
+      .values({
+        scope: 'user',
+        userId,
+        businessId: null,
+        feature: config.feature,
+        action: config.action,
+        count: 1,
+        windowStart,
+        windowEnd,
+      })
+      .returning({ count: usage.count })
+
+    return inserted?.count ?? 1
+  })
+}

--- a/src/app/api/messages/__tests__/conversation-route.test.ts
+++ b/src/app/api/messages/__tests__/conversation-route.test.ts
@@ -21,6 +21,16 @@ jest.mock('@/lib/rate-limiting', () => ({
   checkRateLimit: jest.fn(),
 }))
 
+jest.mock('@server/usage', () => {
+  const actual = jest.requireActual('@server/usage')
+  return {
+    ...actual,
+    getUserSubscriptionTier: jest.fn(),
+    getUsageCount: jest.fn(),
+    incrementUsage: jest.fn(),
+  }
+})
+
 const createRequest = (url: string, init?: { method?: string; body?: unknown; headers?: Record<string, string> }) => {
   const serializedBody =
     typeof init?.body === 'string' ? init.body : init?.body !== undefined ? JSON.stringify(init.body) : undefined
@@ -66,6 +76,12 @@ import {
   serializeConversation,
   serializeMessage,
 } from '@server/messages'
+import {
+  checkQuota,
+  getUserSubscriptionTier,
+  getUsageCount,
+  incrementUsage,
+} from '@server/usage'
 
 describe('/api/messages/[conversationId]', () => {
   const baseUser = {
@@ -79,6 +95,9 @@ describe('/api/messages/[conversationId]', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    ;(getUserSubscriptionTier as jest.Mock).mockResolvedValue('free')
+    ;(getUsageCount as jest.Mock).mockResolvedValue(0)
+    ;(incrementUsage as jest.Mock).mockResolvedValue(1)
   })
 
   describe('GET', () => {
@@ -226,6 +245,32 @@ describe('/api/messages/[conversationId]', () => {
       expect(payload.error).toBe('Too many messages. Please try again later.')
     })
 
+    it('returns 429 when the free plan daily quota is reached', async () => {
+      ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
+      ;(checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true })
+      ;(getUserSubscriptionTier as jest.Mock).mockResolvedValue('free')
+
+      const quota = checkQuota('free', 'messages')
+      expect(quota.limit).not.toBeNull()
+      ;(getUsageCount as jest.Mock).mockResolvedValue(quota.limit)
+
+      const response = await POST(
+        createRequest(`http://localhost/api/messages/${conversationId}`, {
+          method: 'POST',
+          body: { body: 'Hello!' },
+        }),
+        { params: { conversationId } },
+      )
+
+      expect(response.status).toBe(429)
+      const payload = await response.json()
+      expect(payload.error).toMatch(/messaging/i)
+      expect(payload.limit).toBe(quota.limit)
+      expect(payload.period).toBe(quota.period)
+      expect(addMessageToConversation).not.toHaveBeenCalled()
+      expect(incrementUsage).not.toHaveBeenCalled()
+    })
+
     it('validates payload', async () => {
       ;(requireUser as jest.Mock).mockResolvedValue(baseUser)
       ;(checkRateLimit as jest.Mock).mockResolvedValue({ allowed: true })
@@ -295,6 +340,7 @@ describe('/api/messages/[conversationId]', () => {
       })
 
       expect(addMessageToConversation).toHaveBeenCalledWith(conversationId, { body: 'Hello!' }, baseUser)
+      expect(incrementUsage).toHaveBeenCalledWith(baseUser.id, 'day', 'messages')
     })
 
     it('handles HttpErrors from the server module', async () => {

--- a/src/app/api/messages/start/route.ts
+++ b/src/app/api/messages/start/route.ts
@@ -1,7 +1,14 @@
 import { NextResponse } from 'next/server'
 
 import { checkRateLimit } from '@/lib/rate-limiting'
+import {
+  checkQuota,
+  getUsageCount,
+  getUserSubscriptionTier,
+  incrementUsage,
+} from '@server/usage'
 import { HttpError, requireUser } from '@server/auth'
+import type { SubscriptionPlan } from '@shared/schema'
 import {
   serializeConversation,
   serializeMessage,
@@ -34,6 +41,30 @@ export async function POST(request: Request) {
       )
     }
 
+    let quota: ReturnType<typeof checkQuota> | null = null
+    let subscriptionTier: SubscriptionPlan | null = null
+
+    if (user.role !== 'admin') {
+      subscriptionTier = await getUserSubscriptionTier(user.id)
+      quota = checkQuota(subscriptionTier, 'messages')
+
+      if (quota.limit !== null) {
+        const currentUsage = await getUsageCount(user.id, quota.period, 'messages')
+
+        if (currentUsage >= quota.limit) {
+          return NextResponse.json(
+            {
+              error: 'Daily messaging limit reached for the Free plan. Upgrade for unlimited chats.',
+              limit: quota.limit,
+              period: quota.period,
+              tier: subscriptionTier,
+            },
+            { status: 429 },
+          )
+        }
+      }
+    }
+
     const body = await request.json()
     const parsed = startConversationSchema.safeParse(body)
 
@@ -48,6 +79,10 @@ export async function POST(request: Request) {
     }
 
     const result = await startConversation(parsed.data, user)
+
+    if (user.role !== 'admin' && quota) {
+      await incrementUsage(user.id, quota.period, 'messages')
+    }
 
     return NextResponse.json(
       {


### PR DESCRIPTION
## Summary
- add server-side usage tracking helpers that read active subscription tiers and manage per-period counters
- enforce per-plan quotas for classifieds, announcements, and messaging APIs with friendly 429 responses
- expand API route tests to cover quota enforcement and ensure usage counters increment on success

## Testing
- npm test -- --runTestsByPath src/app/api/classifieds/__tests__/route.test.ts src/app/api/announcements/__tests__/routes.test.ts src/app/api/messages/__tests__/start-route.test.ts src/app/api/messages/__tests__/conversation-route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cce84e5750832bb8a64a72aee5acb8