### PR TITLE
Add admin dashboard UI and moderation endpoints

### DIFF
--- a/server/admin.ts
+++ b/server/admin.ts
@@ -1,14 +1,32 @@
-import { and, desc, eq, gte, gt, ilike, isNull, ne, or, sql } from 'drizzle-orm'
+import { and, desc, eq, gte, gt, ilike, inArray, isNull, ne, or, sql } from 'drizzle-orm'
 
 import {
+  announcements,
   businesses,
   classifieds,
   db,
   events,
+  messages,
   profiles,
   reports,
   users,
 } from '@/lib/db'
+import { HttpError } from './auth'
+import {
+  userRoles,
+  type AnnouncementAudience,
+  type AnnouncementType,
+  type BusinessPlan,
+  type BusinessStatus,
+  type ClassifiedStatus,
+  type MembershipTier,
+  type ReportStatus,
+  type ReportTargetType,
+  type UserRole,
+  type UserStatus,
+} from '@shared/schema'
+
+const ADMIN_DEFAULT_LIMIT = 50
 
 const COUNT_COLUMN = sql<number>`cast(count(*) as integer)`
 
@@ -163,4 +181,474 @@ export async function searchAdminDirectory(query: string, options: { limit?: num
       createdAt: row.createdAt,
     })),
   }
+}
+
+const sanitizeLimit = (limit?: number) => Math.max(1, Math.min(ADMIN_DEFAULT_LIMIT, limit ?? ADMIN_DEFAULT_LIMIT))
+
+export type AdminUserRecord = {
+  id: string
+  email: string
+  role: UserRole
+  status: UserStatus
+  membershipTier: MembershipTier
+  displayName: string | null
+  lastSignInAt: Date | null
+  createdAt: Date
+}
+
+export async function listAdminUsers(options: { limit?: number; search?: string } = {}): Promise<AdminUserRecord[]> {
+  const limit = sanitizeLimit(options.limit)
+  const conditions: Array<ReturnType<typeof ilike>> = []
+
+  if (options.search?.trim()) {
+    const pattern = `%${escapeLikePattern(options.search.trim())}%`
+    conditions.push(ilike(users.email, pattern))
+    conditions.push(ilike(profiles.displayName, pattern))
+  }
+
+  let query = db
+    .select({
+      id: users.id,
+      email: users.email,
+      role: users.role,
+      status: users.status,
+      membershipTier: users.membershipTier,
+      lastSignInAt: users.lastSignInAt,
+      createdAt: users.createdAt,
+      displayName: profiles.displayName,
+    })
+    .from(users)
+    .leftJoin(profiles, eq(profiles.userId, users.id))
+    .orderBy(desc(users.createdAt))
+    .limit(limit)
+
+  if (conditions.length === 1) {
+    query = query.where(conditions[0])
+  } else if (conditions.length > 1) {
+    query = query.where(or(...conditions))
+  }
+
+  const rows = await query
+
+  return rows.map((row) => ({
+    id: row.id,
+    email: row.email,
+    role: row.role,
+    status: row.status,
+    membershipTier: row.membershipTier,
+    displayName: row.displayName ?? null,
+    lastSignInAt: row.lastSignInAt ?? null,
+    createdAt: row.createdAt,
+  }))
+}
+
+export async function updateUserRole(userId: string, nextRole: UserRole): Promise<void> {
+  if (!userRoles.includes(nextRole)) {
+    throw new HttpError(400, 'Unsupported role requested')
+  }
+
+  const [updated] = await db
+    .update(users)
+    .set({ role: nextRole, updatedAt: new Date() })
+    .where(eq(users.id, userId))
+    .returning({ id: users.id })
+
+  if (!updated) {
+    throw new HttpError(404, 'User not found')
+  }
+}
+
+export type AdminBusinessRecord = {
+  id: string
+  name: string
+  email: string | null
+  status: BusinessStatus
+  plan: BusinessPlan
+  ownerId: string
+  ownerEmail: string
+  createdAt: Date
+}
+
+export async function listAdminBusinesses(options: { limit?: number; search?: string } = {}): Promise<AdminBusinessRecord[]> {
+  const limit = sanitizeLimit(options.limit)
+  const filters: Array<ReturnType<typeof ilike>> = []
+
+  if (options.search?.trim()) {
+    const pattern = `%${escapeLikePattern(options.search.trim())}%`
+    filters.push(ilike(businesses.name, pattern))
+    filters.push(ilike(businesses.email, pattern))
+  }
+
+  let query = db
+    .select({
+      id: businesses.id,
+      name: businesses.name,
+      email: businesses.email,
+      status: businesses.status,
+      plan: businesses.plan,
+      ownerId: businesses.ownerId,
+      ownerEmail: users.email,
+      createdAt: businesses.createdAt,
+    })
+    .from(businesses)
+    .innerJoin(users, eq(users.id, businesses.ownerId))
+    .orderBy(desc(businesses.createdAt))
+    .limit(limit)
+
+  if (filters.length === 1) {
+    query = query.where(filters[0])
+  } else if (filters.length > 1) {
+    query = query.where(or(...filters))
+  }
+
+  const rows = await query
+
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    email: row.email,
+    status: row.status,
+    plan: row.plan,
+    ownerId: row.ownerId,
+    ownerEmail: row.ownerEmail,
+    createdAt: row.createdAt,
+  }))
+}
+
+export async function setBusinessVerification(businessId: string, verified: boolean): Promise<BusinessStatus> {
+  const nextStatus: BusinessStatus = verified ? 'published' : 'review'
+
+  const [updated] = await db
+    .update(businesses)
+    .set({ status: nextStatus, updatedAt: new Date() })
+    .where(eq(businesses.id, businessId))
+    .returning({ status: businesses.status })
+
+  if (!updated) {
+    throw new HttpError(404, 'Business not found')
+  }
+
+  return updated.status
+}
+
+export async function setBusinessPremium(businessId: string, premium: boolean): Promise<BusinessPlan> {
+  const nextPlan: BusinessPlan = premium ? 'premium' : 'standard'
+
+  const [updated] = await db
+    .update(businesses)
+    .set({ plan: nextPlan, updatedAt: new Date() })
+    .where(eq(businesses.id, businessId))
+    .returning({ plan: businesses.plan })
+
+  if (!updated) {
+    throw new HttpError(404, 'Business not found')
+  }
+
+  return updated.plan
+}
+
+export type AdminAnnouncementRecord = {
+  id: string
+  title: string
+  isApproved: boolean
+  authorId: string
+  authorEmail: string
+  createdAt: Date
+  publishedAt: Date | null
+  type: AnnouncementType
+  audience: AnnouncementAudience
+}
+
+export async function listAdminAnnouncements(options: { limit?: number } = {}): Promise<AdminAnnouncementRecord[]> {
+  const limit = sanitizeLimit(options.limit)
+
+  const rows = await db
+    .select({
+      id: announcements.id,
+      title: announcements.title,
+      isApproved: announcements.isApproved,
+      authorId: announcements.authorId,
+      authorEmail: users.email,
+      createdAt: announcements.createdAt,
+      publishedAt: announcements.publishedAt,
+      type: announcements.type,
+      audience: announcements.audience,
+    })
+    .from(announcements)
+    .innerJoin(users, eq(users.id, announcements.authorId))
+    .orderBy(desc(announcements.createdAt))
+    .limit(limit)
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    isApproved: row.isApproved,
+    authorId: row.authorId,
+    authorEmail: row.authorEmail,
+    createdAt: row.createdAt,
+    publishedAt: row.publishedAt ?? null,
+    type: row.type,
+    audience: row.audience,
+  }))
+}
+
+export async function setAnnouncementApproval(
+  announcementId: string,
+  approved: boolean,
+): Promise<{ isApproved: boolean; publishedAt: Date | null }> {
+  const now = new Date()
+  const [updated] = await db
+    .update(announcements)
+    .set({
+      isApproved: approved,
+      publishedAt: approved ? now : null,
+      updatedAt: now,
+    })
+    .where(eq(announcements.id, announcementId))
+    .returning({ isApproved: announcements.isApproved, publishedAt: announcements.publishedAt })
+
+  if (!updated) {
+    throw new HttpError(404, 'Announcement not found')
+  }
+
+  return {
+    isApproved: updated.isApproved,
+    publishedAt: updated.publishedAt ?? null,
+  }
+}
+
+export type AdminClassifiedRecord = {
+  id: string
+  title: string
+  status: ClassifiedStatus
+  ownerId: string
+  ownerEmail: string
+  createdAt: Date
+}
+
+export async function listAdminClassifieds(options: { limit?: number } = {}): Promise<AdminClassifiedRecord[]> {
+  const limit = sanitizeLimit(options.limit)
+
+  const rows = await db
+    .select({
+      id: classifieds.id,
+      title: classifieds.title,
+      status: classifieds.status,
+      ownerId: classifieds.ownerId,
+      ownerEmail: users.email,
+      createdAt: classifieds.createdAt,
+    })
+    .from(classifieds)
+    .innerJoin(users, eq(users.id, classifieds.ownerId))
+    .orderBy(desc(classifieds.createdAt))
+    .limit(limit)
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    status: row.status,
+    ownerId: row.ownerId,
+    ownerEmail: row.ownerEmail,
+    createdAt: row.createdAt,
+  }))
+}
+
+export async function setClassifiedVisibility(classifiedId: string, hidden: boolean): Promise<ClassifiedStatus> {
+  const nextStatus: ClassifiedStatus = hidden ? 'archived' : 'published'
+
+  const [updated] = await db
+    .update(classifieds)
+    .set({ status: nextStatus, updatedAt: new Date() })
+    .where(eq(classifieds.id, classifiedId))
+    .returning({ status: classifieds.status })
+
+  if (!updated) {
+    throw new HttpError(404, 'Classified not found')
+  }
+
+  return updated.status
+}
+
+export type AdminReportRecord = {
+  id: string
+  reporterId: string
+  reporterEmail: string
+  targetType: ReportTargetType
+  targetId: string
+  status: ReportStatus
+  reason: string
+  createdAt: Date
+  targetLabel: string
+  targetUrl: string | null
+}
+
+const REPORT_ADMIN_SECTIONS: Partial<Record<ReportTargetType, string>> = {
+  user: '/admin/users',
+  business: '/admin/businesses',
+  announcement: '/admin/announcements',
+  classified: '/admin/classifieds',
+}
+
+const REPORT_PUBLIC_SECTIONS: Partial<Record<ReportTargetType, string>> = {
+  event: '/events',
+  message: '/messages',
+}
+
+const buildReportTargetUrl = (targetType: ReportTargetType, targetId: string): string | null => {
+  const adminBase = REPORT_ADMIN_SECTIONS[targetType]
+  if (adminBase) {
+    return `${adminBase}#${targetId}`
+  }
+
+  const publicBase = REPORT_PUBLIC_SECTIONS[targetType]
+  if (publicBase) {
+    return publicBase
+  }
+
+  return null
+}
+
+export async function listAdminReports(options: { limit?: number } = {}): Promise<AdminReportRecord[]> {
+  const limit = sanitizeLimit(options.limit)
+
+  const rows = await db
+    .select({
+      id: reports.id,
+      reporterId: reports.reporterId,
+      reporterEmail: users.email,
+      targetType: reports.targetType,
+      targetId: reports.targetId,
+      status: reports.status,
+      reason: reports.reason,
+      createdAt: reports.createdAt,
+    })
+    .from(reports)
+    .innerJoin(users, eq(users.id, reports.reporterId))
+    .orderBy(desc(reports.createdAt))
+    .limit(limit)
+
+  const targetsByType = rows.reduce<Record<ReportTargetType, Set<string>>>((acc, row) => {
+    if (!acc[row.targetType]) {
+      acc[row.targetType] = new Set<string>()
+    }
+    acc[row.targetType].add(row.targetId)
+    return acc
+  }, {} as Record<ReportTargetType, Set<string>>)
+
+  const [userTargets, businessTargets, announcementTargets, classifiedTargets, eventTargets, messageTargets] = await Promise.all([
+    targetsByType.user?.size
+      ? db
+          .select({ id: users.id, email: users.email, displayName: profiles.displayName })
+          .from(users)
+          .leftJoin(profiles, eq(profiles.userId, users.id))
+          .where(inArray(users.id, Array.from(targetsByType.user)))
+      : Promise.resolve([]),
+    targetsByType.business?.size
+      ? db
+          .select({ id: businesses.id, name: businesses.name })
+          .from(businesses)
+          .where(inArray(businesses.id, Array.from(targetsByType.business)))
+      : Promise.resolve([]),
+    targetsByType.announcement?.size
+      ? db
+          .select({ id: announcements.id, title: announcements.title })
+          .from(announcements)
+          .where(inArray(announcements.id, Array.from(targetsByType.announcement)))
+      : Promise.resolve([]),
+    targetsByType.classified?.size
+      ? db
+          .select({ id: classifieds.id, title: classifieds.title })
+          .from(classifieds)
+          .where(inArray(classifieds.id, Array.from(targetsByType.classified)))
+      : Promise.resolve([]),
+    targetsByType.event?.size
+      ? db
+          .select({ id: events.id, title: events.title })
+          .from(events)
+          .where(inArray(events.id, Array.from(targetsByType.event)))
+      : Promise.resolve([]),
+    targetsByType.message?.size
+      ? db
+          .select({ id: messages.id, body: messages.body })
+          .from(messages)
+          .where(inArray(messages.id, Array.from(targetsByType.message)))
+      : Promise.resolve([]),
+  ])
+
+  const userMap = new Map<string, string>(
+    userTargets.map((row) => [row.id, row.displayName ?? row.email ?? row.id]),
+  )
+  const businessMap = new Map<string, string>(businessTargets.map((row) => [row.id, row.name]))
+  const announcementMap = new Map<string, string>(announcementTargets.map((row) => [row.id, row.title]))
+  const classifiedMap = new Map<string, string>(classifiedTargets.map((row) => [row.id, row.title]))
+  const eventMap = new Map<string, string>(eventTargets.map((row) => [row.id, row.title]))
+  const messageMap = new Map<string, string>(
+    messageTargets.map((row) => [row.id, row.body.slice(0, 80)]),
+  )
+
+  return rows.map((row) => {
+    let targetLabel: string
+
+    switch (row.targetType) {
+      case 'user':
+        targetLabel = userMap.get(row.targetId) ?? `User ${row.targetId}`
+        break
+      case 'business':
+        targetLabel = businessMap.get(row.targetId) ?? `Business ${row.targetId}`
+        break
+      case 'announcement':
+        targetLabel = announcementMap.get(row.targetId) ?? `Announcement ${row.targetId}`
+        break
+      case 'classified':
+        targetLabel = classifiedMap.get(row.targetId) ?? `Classified ${row.targetId}`
+        break
+      case 'event':
+        targetLabel = eventMap.get(row.targetId) ?? `Event ${row.targetId}`
+        break
+      case 'message':
+        targetLabel = messageMap.get(row.targetId) ?? `Message ${row.targetId}`
+        break
+      default:
+        targetLabel = row.targetId
+    }
+
+    return {
+      id: row.id,
+      reporterId: row.reporterId,
+      reporterEmail: row.reporterEmail,
+      targetType: row.targetType,
+      targetId: row.targetId,
+      status: row.status,
+      reason: row.reason,
+      createdAt: row.createdAt,
+      targetLabel,
+      targetUrl: buildReportTargetUrl(row.targetType, row.targetId),
+    }
+  })
+}
+
+export async function updateReportStatus(
+  reportId: string,
+  status: Extract<ReportStatus, 'resolved' | 'dismissed'>,
+  resolution?: string,
+): Promise<ReportStatus> {
+  if (!['resolved', 'dismissed'].includes(status)) {
+    throw new HttpError(400, 'Unsupported report status transition')
+  }
+
+  const [updated] = await db
+    .update(reports)
+    .set({
+      status,
+      resolution: resolution ?? null,
+      updatedAt: new Date(),
+    })
+    .where(eq(reports.id, reportId))
+    .returning({ status: reports.status })
+
+  if (!updated) {
+    throw new HttpError(404, 'Report not found')
+  }
+
+  return updated.status
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -15,7 +15,7 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
-export const userRoles = ["member", "moderator", "admin"] as const;
+export const userRoles = ["member", "business_owner", "moderator", "admin"] as const;
 export type UserRole = (typeof userRoles)[number];
 
 export const userStatuses = ["active", "inactive", "suspended"] as const;
@@ -143,7 +143,7 @@ export const users = pgTable(
     ),
     usersRoleCheck: check(
       "users_role_check",
-      sql`${table.role} in ('member', 'moderator', 'admin')`,
+      sql`${table.role} in ('member', 'business_owner', 'moderator', 'admin')`,
     ),
     usersStatusCheck: check(
       "users_status_check",

--- a/src/app/admin/_components/AdminNav.tsx
+++ b/src/app/admin/_components/AdminNav.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+import { cn } from '@/lib/utils'
+
+export type AdminNavItem = {
+  name: string
+  href: string
+}
+
+type AdminNavProps = {
+  items: readonly AdminNavItem[]
+}
+
+export function AdminNav({ items }: AdminNavProps) {
+  const pathname = usePathname()
+
+  return (
+    <nav className="flex flex-wrap gap-3 border-b border-gray-200 pb-3">
+      {items.map((item) => {
+        const isActive = pathname === item.href || (item.href !== '/admin' && pathname.startsWith(item.href))
+
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              'px-4 py-2 rounded-lg text-sm font-medium transition-colors',
+              isActive
+                ? 'bg-primary-600 text-white shadow-sm'
+                : 'text-gray-600 hover:text-primary-600 hover:bg-primary-50',
+            )}
+          >
+            {item.name}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/app/admin/_components/AnnouncementsTable.tsx
+++ b/src/app/admin/_components/AnnouncementsTable.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/Button'
+import type { AnnouncementAudience, AnnouncementType } from '@shared/schema'
+
+type SerializedAdminAnnouncement = {
+  id: string
+  title: string
+  isApproved: boolean
+  authorEmail: string
+  createdAt: string
+  publishedAt: string | null
+  type: AnnouncementType
+  audience: AnnouncementAudience
+}
+
+type AnnouncementsTableProps = {
+  announcements: SerializedAdminAnnouncement[]
+}
+
+const formatDate = (value: string | null) => {
+  if (!value) {
+    return 'Pending'
+  }
+
+  return new Date(value).toLocaleString()
+}
+
+export function AnnouncementsTable({ announcements }: AnnouncementsTableProps) {
+  const [rows, setRows] = useState(announcements)
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const updateApproval = async (announcementId: string, approved: boolean) => {
+    setPendingId(announcementId)
+    setErrorMessage(null)
+
+    try {
+      const response = await fetch(`/api/admin/announcements/${announcementId}/approval`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ approved }),
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}))
+        throw new Error(payload.error ?? 'Failed to update announcement approval')
+      }
+
+      const payload = await response.json()
+
+      setRows((previous) =>
+        previous.map((row) =>
+          row.id === announcementId
+            ? {
+                ...row,
+                isApproved: payload.isApproved as boolean,
+                publishedAt: payload.publishedAt,
+              }
+            : row,
+        ),
+      )
+    } catch (error) {
+      console.error('Failed to update announcement approval', error)
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to update announcement')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {errorMessage && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+          <thead>
+            <tr className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <th scope="col" className="px-4 py-3">
+                Title
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Type
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Audience
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Author
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Published
+              </th>
+              <th scope="col" className="px-4 py-3 text-right">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {rows.map((announcement) => (
+              <tr key={announcement.id} id={`announcement-${announcement.id}`}>
+                <td className="px-4 py-3">
+                  <div className="font-medium text-gray-900">{announcement.title}</div>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600 capitalize">{announcement.type}</td>
+                <td className="px-4 py-3 text-sm text-gray-600 capitalize">{announcement.audience}</td>
+                <td className="px-4 py-3 text-sm text-gray-600">{announcement.authorEmail}</td>
+                <td className="px-4 py-3 text-sm text-gray-600">{formatDate(announcement.publishedAt)}</td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center justify-end gap-2">
+                    <Button
+                      size="sm"
+                      variant={announcement.isApproved ? 'outline' : 'primary'}
+                      onClick={() => updateApproval(announcement.id, true)}
+                      disabled={pendingId === announcement.id || announcement.isApproved}
+                    >
+                      Approve
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => updateApproval(announcement.id, false)}
+                      disabled={pendingId === announcement.id || !announcement.isApproved}
+                    >
+                      Reject
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/_components/BusinessesTable.tsx
+++ b/src/app/admin/_components/BusinessesTable.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import type { BusinessPlan, BusinessStatus } from '@shared/schema'
+
+type SerializedAdminBusiness = {
+  id: string
+  name: string
+  email: string | null
+  status: BusinessStatus
+  plan: BusinessPlan
+  ownerEmail: string
+  createdAt: string
+  verified: boolean
+  premium: boolean
+}
+
+type BusinessesTableProps = {
+  businesses: SerializedAdminBusiness[]
+}
+
+const formatDate = (value: string) => new Date(value).toLocaleDateString()
+
+export function BusinessesTable({ businesses }: BusinessesTableProps) {
+  const [rows, setRows] = useState(businesses)
+  const [query, setQuery] = useState('')
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) {
+      return rows
+    }
+
+    const needle = query.trim().toLowerCase()
+    return rows.filter((row) => row.name.toLowerCase().includes(needle))
+  }, [rows, query])
+
+  const toggleVerification = async (businessId: string, verified: boolean) => {
+    setPendingId(businessId)
+    setErrorMessage(null)
+
+    try {
+      const response = await fetch(`/api/admin/businesses/${businessId}/verification`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ verified }),
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}))
+        throw new Error(payload.error ?? 'Failed to update verification')
+      }
+
+      const payload = await response.json()
+
+      setRows((previous) =>
+        previous.map((row) =>
+          row.id === businessId
+            ? { ...row, verified: payload.verified as boolean, status: payload.status as BusinessStatus }
+            : row,
+        ),
+      )
+    } catch (error) {
+      console.error('Failed to update business verification', error)
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to update verification')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  const togglePremium = async (businessId: string, premium: boolean) => {
+    setPendingId(businessId)
+    setErrorMessage(null)
+
+    try {
+      const response = await fetch(`/api/admin/businesses/${businessId}/plan`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ premium }),
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}))
+        throw new Error(payload.error ?? 'Failed to update plan')
+      }
+
+      const payload = await response.json()
+
+      setRows((previous) =>
+        previous.map((row) =>
+          row.id === businessId
+            ? { ...row, premium, plan: payload.plan as BusinessPlan }
+            : row,
+        ),
+      )
+    } catch (error) {
+      console.error('Failed to update business premium flag', error)
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to update premium flag')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex-1 max-w-sm">
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search by business name"
+            aria-label="Search businesses"
+          />
+        </div>
+        <p className="text-sm text-gray-500">
+          Showing <span className="font-medium text-gray-900">{filtered.length}</span> of{' '}
+          <span className="font-medium text-gray-900">{rows.length}</span> businesses
+        </p>
+      </div>
+
+      {errorMessage && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+          <thead>
+            <tr className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <th scope="col" className="px-4 py-3">
+                Business
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Owner
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Plan
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Status
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Created
+              </th>
+              <th scope="col" className="px-4 py-3 text-right">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {filtered.map((business) => (
+              <tr key={business.id} id={`business-${business.id}`}>
+                <td className="px-4 py-3">
+                  <div className="font-medium text-gray-900">{business.name}</div>
+                  <div className="text-xs text-gray-500">{business.email ?? 'No email'}</div>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">{business.ownerEmail}</td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${
+                      business.premium
+                        ? 'bg-amber-100 text-amber-800'
+                        : 'bg-gray-100 text-gray-600'
+                    }`}
+                  >
+                    {business.plan.toUpperCase()}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600 capitalize">
+                  {business.verified ? 'Published' : business.status}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">{formatDate(business.createdAt)}</td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center justify-end gap-2">
+                    <Button
+                      variant={business.verified ? 'outline' : 'primary'}
+                      size="sm"
+                      onClick={() => toggleVerification(business.id, !business.verified)}
+                      loading={pendingId === business.id}
+                    >
+                      {business.verified ? 'Unverify' : 'Verify'}
+                    </Button>
+                    <Button
+                      variant={business.premium ? 'outline' : 'secondary'}
+                      size="sm"
+                      onClick={() => togglePremium(business.id, !business.premium)}
+                      disabled={pendingId === business.id}
+                    >
+                      {business.premium ? 'Set Standard' : 'Mark Premium'}
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/_components/ClassifiedsTable.tsx
+++ b/src/app/admin/_components/ClassifiedsTable.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/Button'
+import type { ClassifiedStatus } from '@shared/schema'
+
+type SerializedAdminClassified = {
+  id: string
+  title: string
+  status: ClassifiedStatus
+  ownerEmail: string
+  createdAt: string
+}
+
+type ClassifiedsTableProps = {
+  classifieds: SerializedAdminClassified[]
+}
+
+const formatDate = (value: string) => new Date(value).toLocaleString()
+
+export function ClassifiedsTable({ classifieds }: ClassifiedsTableProps) {
+  const [rows, setRows] = useState(classifieds)
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const toggleVisibility = async (classifiedId: string, hidden: boolean) => {
+    setPendingId(classifiedId)
+    setErrorMessage(null)
+
+    try {
+      const response = await fetch(`/api/admin/classifieds/${classifiedId}/visibility`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hidden }),
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}))
+        throw new Error(payload.error ?? 'Failed to update classified')
+      }
+
+      const payload = await response.json()
+
+      setRows((previous) =>
+        previous.map((row) =>
+          row.id === classifiedId ? { ...row, status: payload.status as ClassifiedStatus } : row,
+        ),
+      )
+    } catch (error) {
+      console.error('Failed to update classified visibility', error)
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to update classified')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {errorMessage && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+          <thead>
+            <tr className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <th scope="col" className="px-4 py-3">
+                Title
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Owner
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Status
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Created
+              </th>
+              <th scope="col" className="px-4 py-3 text-right">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {rows.map((classified) => {
+              const hidden = classified.status !== 'published'
+
+              return (
+                <tr key={classified.id} id={`classified-${classified.id}`}>
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-gray-900">{classified.title}</div>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-600">{classified.ownerEmail}</td>
+                  <td className="px-4 py-3 text-sm text-gray-600 capitalize">{classified.status}</td>
+                  <td className="px-4 py-3 text-sm text-gray-600">{formatDate(classified.createdAt)}</td>
+                  <td className="px-4 py-3 text-right">
+                    <Button
+                      size="sm"
+                      variant={hidden ? 'secondary' : 'outline'}
+                      onClick={() => toggleVisibility(classified.id, !hidden)}
+                      loading={pendingId === classified.id}
+                    >
+                      {hidden ? 'Unhide' : 'Hide'}
+                    </Button>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/_components/ReportsTable.tsx
+++ b/src/app/admin/_components/ReportsTable.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/Button'
+import type { ReportStatus, ReportTargetType } from '@shared/schema'
+
+type SerializedAdminReport = {
+  id: string
+  reporterEmail: string
+  targetType: ReportTargetType
+  targetLabel: string
+  targetUrl: string | null
+  status: ReportStatus
+  reason: string
+  createdAt: string
+}
+
+type ReportsTableProps = {
+  reports: SerializedAdminReport[]
+}
+
+const formatDate = (value: string) => new Date(value).toLocaleString()
+
+const RESOLUTION_MESSAGES: Record<'resolved' | 'dismissed', string> = {
+  resolved: 'Marked as resolved via admin dashboard',
+  dismissed: 'Closed by admin via dashboard',
+}
+
+export function ReportsTable({ reports }: ReportsTableProps) {
+  const [rows, setRows] = useState(reports)
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const updateStatus = async (
+    reportId: string,
+    status: 'resolved' | 'dismissed',
+  ) => {
+    setPendingId(reportId)
+    setErrorMessage(null)
+
+    try {
+      const response = await fetch(`/api/admin/reports/${reportId}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status, resolution: RESOLUTION_MESSAGES[status] }),
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}))
+        throw new Error(payload.error ?? 'Failed to update report')
+      }
+
+      const payload = await response.json()
+
+      setRows((previous) =>
+        previous.map((row) =>
+          row.id === reportId ? { ...row, status: payload.status as ReportStatus } : row,
+        ),
+      )
+    } catch (error) {
+      console.error('Failed to update report status', error)
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to update report')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {errorMessage && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+          <thead>
+            <tr className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <th scope="col" className="px-4 py-3">
+                Target
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Reporter
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Reason
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Created
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Status
+              </th>
+              <th scope="col" className="px-4 py-3 text-right">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {rows.map((report) => (
+              <tr key={report.id} id={`report-${report.id}`}>
+                <td className="px-4 py-3">
+                  <div className="font-medium text-gray-900">{report.targetLabel}</div>
+                  <div className="text-xs text-gray-500 capitalize">{report.targetType}</div>
+                  {report.targetUrl ? (
+                    <Link
+                      href={report.targetUrl}
+                      className="text-xs font-medium text-primary-600 hover:underline"
+                    >
+                      View entity
+                    </Link>
+                  ) : (
+                    <span className="text-xs text-gray-400">No link available</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">{report.reporterEmail}</td>
+                <td className="px-4 py-3 text-sm text-gray-600">{report.reason}</td>
+                <td className="px-4 py-3 text-sm text-gray-600">{formatDate(report.createdAt)}</td>
+                <td className="px-4 py-3 text-sm text-gray-600 capitalize">{report.status}</td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center justify-end gap-2">
+                    <Button
+                      size="sm"
+                      variant="primary"
+                      onClick={() => updateStatus(report.id, 'resolved')}
+                      disabled={pendingId === report.id || report.status === 'resolved'}
+                    >
+                      Resolve
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => updateStatus(report.id, 'dismissed')}
+                      disabled={pendingId === report.id || report.status === 'dismissed'}
+                    >
+                      Close
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/_components/UsersTable.tsx
+++ b/src/app/admin/_components/UsersTable.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { Select } from '@/components/ui/Select'
+import type { MembershipTier, UserRole, UserStatus } from '@shared/schema'
+
+type SerializedAdminUser = {
+  id: string
+  email: string
+  role: UserRole
+  status: UserStatus
+  membershipTier: MembershipTier
+  displayName: string | null
+  lastSignInAt: string | null
+  createdAt: string
+}
+
+type UsersTableProps = {
+  users: SerializedAdminUser[]
+}
+
+const ROLE_OPTIONS: Array<{ value: UserRole; label: string }> = [
+  { value: 'member', label: 'Member' },
+  { value: 'business_owner', label: 'Business Owner' },
+  { value: 'admin', label: 'Admin' },
+]
+
+const formatDateTime = (value: string | null) => {
+  if (!value) {
+    return '—'
+  }
+
+  return new Date(value).toLocaleString()
+}
+
+export function UsersTable({ users }: UsersTableProps) {
+  const [query, setQuery] = useState('')
+  const [rows, setRows] = useState(users)
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) {
+      return rows
+    }
+
+    const needle = query.trim().toLowerCase()
+    return rows.filter((row) => {
+      return (
+        row.email.toLowerCase().includes(needle) ||
+        (row.displayName ? row.displayName.toLowerCase().includes(needle) : false)
+      )
+    })
+  }, [rows, query])
+
+  const handleRoleChange = async (userId: string, role: UserRole) => {
+    setPendingId(userId)
+    setErrorMessage(null)
+
+    try {
+      const response = await fetch(`/api/admin/users/${userId}/role`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role }),
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}))
+        throw new Error(payload.error ?? 'Failed to update role')
+      }
+
+      setRows((previous) =>
+        previous.map((row) => (row.id === userId ? { ...row, role } : row)),
+      )
+    } catch (error) {
+      console.error('Failed to update user role', error)
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to update role')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex-1 max-w-sm">
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search by email or name"
+            aria-label="Search users"
+          />
+        </div>
+        <p className="text-sm text-gray-500">
+          Showing <span className="font-medium text-gray-900">{filtered.length}</span> of{' '}
+          <span className="font-medium text-gray-900">{rows.length}</span> records
+        </p>
+      </div>
+
+      {errorMessage && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+          <thead>
+            <tr className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <th scope="col" className="px-4 py-3">
+                User
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Role
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Membership
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Status
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Last Sign In
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Created
+              </th>
+              <th scope="col" className="px-4 py-3 text-right">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {filtered.map((user) => (
+              <tr key={user.id} id={`user-${user.id}`}>
+                <td className="px-4 py-3">
+                  <div className="font-medium text-gray-900">{user.displayName ?? 'Unknown user'}</div>
+                  <div className="text-xs text-gray-500">{user.email}</div>
+                </td>
+                <td className="px-4 py-3">
+                  <Select
+                    value={user.role}
+                    onChange={(event) => handleRoleChange(user.id, event.target.value as UserRole)}
+                    disabled={pendingId === user.id}
+                    aria-label="Select user role"
+                  >
+                    {ROLE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </Select>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="inline-flex items-center rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">
+                    {user.membershipTier}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600 capitalize">{user.status}</td>
+                <td className="px-4 py-3 text-sm text-gray-600">{formatDateTime(user.lastSignInAt)}</td>
+                <td className="px-4 py-3 text-sm text-gray-600">{formatDateTime(user.createdAt)}</td>
+                <td className="px-4 py-3 text-right">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled
+                    title="Additional user actions coming soon"
+                  >
+                    Manage
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/announcements/page.tsx
+++ b/src/app/admin/announcements/page.tsx
@@ -1,0 +1,34 @@
+import { listAdminAnnouncements } from '@server/admin'
+
+import { AnnouncementsTable } from '../_components/AnnouncementsTable'
+
+const serializeAnnouncements = async () => {
+  const records = await listAdminAnnouncements()
+
+  return records.map((announcement) => ({
+    id: announcement.id,
+    title: announcement.title,
+    isApproved: announcement.isApproved,
+    authorEmail: announcement.authorEmail,
+    createdAt: announcement.createdAt.toISOString(),
+    publishedAt: announcement.publishedAt ? announcement.publishedAt.toISOString() : null,
+    type: announcement.type,
+    audience: announcement.audience,
+  }))
+}
+
+export default async function AdminAnnouncementsPage() {
+  const announcements = await serializeAnnouncements()
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h2 className="text-xl font-semibold text-gray-900">Announcements</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Approve or reject submissions before they surface across the community feeds.
+        </p>
+      </header>
+      <AnnouncementsTable announcements={announcements} />
+    </div>
+  )
+}

--- a/src/app/admin/businesses/page.tsx
+++ b/src/app/admin/businesses/page.tsx
@@ -1,0 +1,36 @@
+import { listAdminBusinesses } from '@server/admin'
+
+import { BusinessesTable } from '../_components/BusinessesTable'
+
+const serializeBusinesses = async () => {
+  const records = await listAdminBusinesses()
+
+  return records.map((business) => ({
+    id: business.id,
+    name: business.name,
+    email: business.email,
+    status: business.status,
+    plan: business.plan,
+    ownerEmail: business.ownerEmail,
+    createdAt: business.createdAt.toISOString(),
+    verified: business.status === 'published',
+    premium: business.plan === 'premium',
+  }))
+}
+
+export default async function AdminBusinessesPage() {
+  const businesses = await serializeBusinesses()
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h2 className="text-xl font-semibold text-gray-900">Businesses</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Verify listings and manage premium placement for featured businesses. Stripe remains the source of truth for billing
+          status; this toggle is for visibility only.
+        </p>
+      </header>
+      <BusinessesTable businesses={businesses} />
+    </div>
+  )
+}

--- a/src/app/admin/classifieds/page.tsx
+++ b/src/app/admin/classifieds/page.tsx
@@ -1,0 +1,31 @@
+import { listAdminClassifieds } from '@server/admin'
+
+import { ClassifiedsTable } from '../_components/ClassifiedsTable'
+
+const serializeClassifieds = async () => {
+  const records = await listAdminClassifieds()
+
+  return records.map((classified) => ({
+    id: classified.id,
+    title: classified.title,
+    status: classified.status,
+    ownerEmail: classified.ownerEmail,
+    createdAt: classified.createdAt.toISOString(),
+  }))
+}
+
+export default async function AdminClassifiedsPage() {
+  const classifieds = await serializeClassifieds()
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h2 className="text-xl font-semibold text-gray-900">Classifieds</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Hide or restore listings that fall outside community standards.
+        </p>
+      </header>
+      <ClassifiedsTable classifieds={classifieds} />
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+import { redirect, notFound } from 'next/navigation'
+
+import { AdminNav } from './_components/AdminNav'
+import { requireUser, UnauthorizedError } from '@server/auth'
+
+export const adminNavItems = [
+  { name: 'Overview', href: '/admin' },
+  { name: 'Users', href: '/admin/users' },
+  { name: 'Businesses', href: '/admin/businesses' },
+  { name: 'Announcements', href: '/admin/announcements' },
+  { name: 'Classifieds', href: '/admin/classifieds' },
+  { name: 'Reports', href: '/admin/reports' },
+] as const
+
+type AdminLayoutProps = {
+  children: ReactNode
+}
+
+export default async function AdminLayout({ children }: AdminLayoutProps) {
+  try {
+    const user = await requireUser()
+
+    if (user.role !== 'admin') {
+      notFound()
+    }
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      redirect('/auth/signin')
+    }
+
+    throw error
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-10">
+      <header className="mb-8">
+        <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Administrative</p>
+        <h1 className="mt-2 text-3xl font-semibold text-gray-900">UiQ Admin Dashboard</h1>
+        <p className="mt-2 text-gray-600">
+          Manage users, businesses, and community content. Actions are logged and subject to rate limiting.
+        </p>
+      </header>
+      <AdminNav items={adminNavItems} />
+      <div className="mt-8 bg-white border border-gray-200 rounded-xl shadow-sm p-6">{children}</div>
+    </div>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,72 @@
+import { getAdminOverview } from '@server/admin'
+
+const overviewCards = (
+  overview: Awaited<ReturnType<typeof getAdminOverview>>,
+) => [
+  {
+    title: 'Total Users',
+    value: overview.users,
+    description: 'Registered members in the community.',
+  },
+  {
+    title: 'Verified Businesses',
+    value: overview.businesses.verified,
+    description: 'Published directory listings.',
+  },
+  {
+    title: 'Businesses Pending Review',
+    value: overview.businesses.unverified,
+    description: 'Awaiting moderation before publishing.',
+  },
+  {
+    title: 'Upcoming Events',
+    value: overview.events.upcoming,
+    description: 'Live and scheduled events.',
+  },
+  {
+    title: 'Active Classifieds',
+    value: overview.classifieds.active,
+    description: 'Listings currently visible to members.',
+  },
+  {
+    title: 'Open Reports',
+    value: overview.reports.open,
+    description: 'Moderation items requiring attention.',
+  },
+]
+
+export default async function AdminOverviewPage() {
+  const overview = await getAdminOverview()
+  const cards = overviewCards(overview)
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <h2 className="text-xl font-semibold text-gray-900">Overview</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Snapshot of key metrics across the UiQ Community Platform.
+        </p>
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {cards.map((card) => (
+            <div
+              key={card.title}
+              className="rounded-xl border border-gray-200 bg-gradient-to-br from-white to-gray-50 p-5 shadow-sm"
+            >
+              <p className="text-sm font-medium text-gray-500">{card.title}</p>
+              <p className="mt-3 text-3xl font-semibold text-gray-900">{card.value}</p>
+              <p className="mt-2 text-sm text-gray-600">{card.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-primary-100 bg-primary-50/60 p-5">
+        <h3 className="text-lg font-semibold text-primary-900">Admin Guidance</h3>
+        <p className="mt-2 text-sm text-primary-800">
+          All moderation actions are audited. Ensure that approval and verification decisions adhere to community guidelines and
+          respect member privacy.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,0 +1,34 @@
+import { listAdminReports } from '@server/admin'
+
+import { ReportsTable } from '../_components/ReportsTable'
+
+const serializeReports = async () => {
+  const records = await listAdminReports()
+
+  return records.map((report) => ({
+    id: report.id,
+    reporterEmail: report.reporterEmail,
+    targetType: report.targetType,
+    targetLabel: report.targetLabel,
+    targetUrl: report.targetUrl,
+    status: report.status,
+    reason: report.reason,
+    createdAt: report.createdAt.toISOString(),
+  }))
+}
+
+export default async function AdminReportsPage() {
+  const reports = await serializeReports()
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h2 className="text-xl font-semibold text-gray-900">Reports</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Resolve community reports, escalate issues, and provide closure for members.
+        </p>
+      </header>
+      <ReportsTable reports={reports} />
+    </div>
+  )
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,34 @@
+import { listAdminUsers } from '@server/admin'
+
+import { UsersTable } from '../_components/UsersTable'
+
+const serializeUsers = async () => {
+  const records = await listAdminUsers()
+
+  return records.map((user) => ({
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    status: user.status,
+    membershipTier: user.membershipTier,
+    displayName: user.displayName,
+    lastSignInAt: user.lastSignInAt ? user.lastSignInAt.toISOString() : null,
+    createdAt: user.createdAt.toISOString(),
+  }))
+}
+
+export default async function AdminUsersPage() {
+  const users = await serializeUsers()
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h2 className="text-xl font-semibold text-gray-900">Users</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Review member accounts, adjust roles, and monitor subscription tiers.
+        </p>
+      </header>
+      <UsersTable users={users} />
+    </div>
+  )
+}

--- a/src/app/api/admin/__tests__/routes.test.ts
+++ b/src/app/api/admin/__tests__/routes.test.ts
@@ -4,6 +4,12 @@ jest.mock('@server/admin', () => {
     ...actual,
     getAdminOverview: jest.fn(),
     searchAdminDirectory: jest.fn(),
+    updateUserRole: jest.fn(),
+    setBusinessVerification: jest.fn(),
+    setBusinessPremium: jest.fn(),
+    setAnnouncementApproval: jest.fn(),
+    setClassifiedVisibility: jest.fn(),
+    updateReportStatus: jest.fn(),
   }
 })
 
@@ -15,16 +21,48 @@ jest.mock('@server/auth', () => {
   }
 })
 
+jest.mock('@/lib/rate-limiting', () => ({
+  checkRateLimit: jest.fn(),
+}))
+
 import { GET as overviewGet } from '../overview/route'
 import { GET as searchGet } from '../search/route'
-import { getAdminOverview, searchAdminDirectory } from '@server/admin'
+import { PATCH as userRolePatch } from '../users/[userId]/role/route'
+import { PATCH as businessVerificationPatch } from '../businesses/[businessId]/verification/route'
+import { PATCH as businessPlanPatch } from '../businesses/[businessId]/plan/route'
+import { PATCH as announcementApprovalPatch } from '../announcements/[announcementId]/approval/route'
+import { PATCH as classifiedVisibilityPatch } from '../classifieds/[classifiedId]/visibility/route'
+import { PATCH as reportStatusPatch } from '../reports/[reportId]/status/route'
+import {
+  getAdminOverview,
+  searchAdminDirectory,
+  setAnnouncementApproval,
+  setBusinessPremium,
+  setBusinessVerification,
+  setClassifiedVisibility,
+  updateReportStatus,
+  updateUserRole,
+} from '@server/admin'
 import { requireUser, UnauthorizedError } from '@server/auth'
+import { checkRateLimit } from '@/lib/rate-limiting'
 
 const createRequest = (url: string) => new Request(url)
+const createJsonRequest = (url: string, body: unknown) =>
+  new Request(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
 
 describe('Admin API routes', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    ;(checkRateLimit as jest.Mock).mockResolvedValue({
+      allowed: true,
+      remaining: 10,
+      resetTime: new Date(Date.now() + 60_000),
+      blocked: false,
+    })
   })
 
   describe('GET /api/admin/overview', () => {
@@ -165,6 +203,145 @@ describe('Admin API routes', () => {
       expect(response.status).toBe(401)
       const payload = await response.json()
       expect(payload.error).toBe('Authentication required')
+    })
+  })
+
+  describe('PATCH /api/admin/users/:id/role', () => {
+    it('updates the user role for admin', async () => {
+      const adminUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(adminUser)
+
+      const response = await userRolePatch(
+        createJsonRequest('http://localhost/api/admin/users/u-1/role', { role: 'business_owner' }),
+        { params: { userId: '11111111-1111-1111-1111-111111111111' } },
+      )
+
+      expect(response.status).toBe(200)
+      expect(updateUserRole).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111', 'business_owner')
+    })
+
+    it('rejects non-admin users', async () => {
+      const memberUser = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(memberUser)
+
+      const response = await userRolePatch(
+        createJsonRequest('http://localhost/api/admin/users/u-1/role', { role: 'admin' }),
+        { params: { userId: '11111111-1111-1111-1111-111111111111' } },
+      )
+
+      expect(response.status).toBe(403)
+      expect(updateUserRole).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('PATCH /api/admin/businesses/:id/verification', () => {
+    it('toggles verification for admin', async () => {
+      const adminUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(adminUser)
+      ;(setBusinessVerification as jest.Mock).mockResolvedValue('published')
+
+      const response = await businessVerificationPatch(
+        createJsonRequest('http://localhost/api/admin/businesses/b-1/verification', { verified: true }),
+        { params: { businessId: '22222222-2222-2222-2222-222222222222' } },
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({ status: 'published', verified: true })
+      expect(setBusinessVerification).toHaveBeenCalledWith('22222222-2222-2222-2222-222222222222', true)
+    })
+
+    it('rejects non-admin users', async () => {
+      const memberUser = { id: 'user-1', role: 'member', email: 'user@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(memberUser)
+
+      const response = await businessVerificationPatch(
+        createJsonRequest('http://localhost/api/admin/businesses/b-1/verification', { verified: true }),
+        { params: { businessId: '22222222-2222-2222-2222-222222222222' } },
+      )
+
+      expect(response.status).toBe(403)
+      expect(setBusinessVerification).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('PATCH /api/admin/businesses/:id/plan', () => {
+    it('updates the business plan toggle', async () => {
+      const adminUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(adminUser)
+      ;(setBusinessPremium as jest.Mock).mockResolvedValue('premium')
+
+      const response = await businessPlanPatch(
+        createJsonRequest('http://localhost/api/admin/businesses/b-1/plan', { premium: true }),
+        { params: { businessId: '33333333-3333-3333-3333-333333333333' } },
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({ plan: 'premium' })
+      expect(setBusinessPremium).toHaveBeenCalledWith('33333333-3333-3333-3333-333333333333', true)
+    })
+  })
+
+  describe('PATCH /api/admin/announcements/:id/approval', () => {
+    it('approves announcements', async () => {
+      const adminUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(adminUser)
+      const now = new Date()
+      ;(setAnnouncementApproval as jest.Mock).mockResolvedValue({ isApproved: true, publishedAt: now })
+
+      const response = await announcementApprovalPatch(
+        createJsonRequest('http://localhost/api/admin/announcements/a-1/approval', { approved: true }),
+        { params: { announcementId: '44444444-4444-4444-4444-444444444444' } },
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({ isApproved: true, publishedAt: now.toISOString() })
+      expect(setAnnouncementApproval).toHaveBeenCalledWith('44444444-4444-4444-4444-444444444444', true)
+    })
+  })
+
+  describe('PATCH /api/admin/classifieds/:id/visibility', () => {
+    it('hides classifieds', async () => {
+      const adminUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(adminUser)
+      ;(setClassifiedVisibility as jest.Mock).mockResolvedValue('archived')
+
+      const response = await classifiedVisibilityPatch(
+        createJsonRequest('http://localhost/api/admin/classifieds/c-1/visibility', { hidden: true }),
+        { params: { classifiedId: '55555555-5555-5555-5555-555555555555' } },
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({ status: 'archived' })
+      expect(setClassifiedVisibility).toHaveBeenCalledWith('55555555-5555-5555-5555-555555555555', true)
+    })
+  })
+
+  describe('PATCH /api/admin/reports/:id/status', () => {
+    it('updates report status', async () => {
+      const adminUser = { id: 'admin-1', role: 'admin', email: 'admin@example.com', status: 'active' } as const
+      ;(requireUser as jest.Mock).mockResolvedValue(adminUser)
+      ;(updateReportStatus as jest.Mock).mockResolvedValue('resolved')
+
+      const response = await reportStatusPatch(
+        createJsonRequest('http://localhost/api/admin/reports/r-1/status', {
+          status: 'resolved',
+          resolution: 'Addressed by admin',
+        }),
+        { params: { reportId: '66666666-6666-6666-6666-666666666666' } },
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({ status: 'resolved' })
+      expect(updateReportStatus).toHaveBeenCalledWith(
+        '66666666-6666-6666-6666-666666666666',
+        'resolved',
+        'Addressed by admin',
+      )
     })
   })
 })

--- a/src/app/api/admin/announcements/[announcementId]/approval/route.ts
+++ b/src/app/api/admin/announcements/[announcementId]/approval/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { setAnnouncementApproval } from '@server/admin'
+import { HttpError, requireUser, UnauthorizedError } from '@server/auth'
+
+const idSchema = z.string().uuid()
+const bodySchema = z.object({ approved: z.boolean() })
+
+type RouteContext = {
+  params: { announcementId: string }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const user = await requireUser()
+
+    if (user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const rateLimit = await checkRateLimit(user.id, 'admin_action')
+
+    if (!rateLimit.allowed) {
+      const retryAfter = Math.max(1, Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000))
+      return NextResponse.json(
+        {
+          error: 'Too many admin actions. Please slow down.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+      )
+    }
+
+    const idResult = idSchema.safeParse(context.params.announcementId)
+
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid announcement id' }, { status: 400 })
+    }
+
+    const payload = bodySchema.safeParse(await request.json())
+
+    if (!payload.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid request body',
+          details: payload.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const result = await setAnnouncementApproval(idResult.data, payload.data.approved)
+
+    return NextResponse.json({
+      isApproved: result.isApproved,
+      publishedAt: result.publishedAt ? result.publishedAt.toISOString() : null,
+    })
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+    }
+
+    console.error('Failed to update announcement approval', error)
+    return NextResponse.json({ error: 'Failed to update announcement approval' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/businesses/[businessId]/plan/route.ts
+++ b/src/app/api/admin/businesses/[businessId]/plan/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { setBusinessPremium } from '@server/admin'
+import { HttpError, requireUser, UnauthorizedError } from '@server/auth'
+
+const idSchema = z.string().uuid()
+const bodySchema = z.object({ premium: z.boolean() })
+
+type RouteContext = {
+  params: { businessId: string }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const user = await requireUser()
+
+    if (user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const rateLimit = await checkRateLimit(user.id, 'admin_action')
+
+    if (!rateLimit.allowed) {
+      const retryAfter = Math.max(1, Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000))
+      return NextResponse.json(
+        {
+          error: 'Too many admin actions. Please slow down.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+      )
+    }
+
+    const idResult = idSchema.safeParse(context.params.businessId)
+
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid business id' }, { status: 400 })
+    }
+
+    const payload = bodySchema.safeParse(await request.json())
+
+    if (!payload.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid request body',
+          details: payload.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const plan = await setBusinessPremium(idResult.data, payload.data.premium)
+
+    return NextResponse.json({ plan })
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+    }
+
+    console.error('Failed to update business plan', error)
+    return NextResponse.json({ error: 'Failed to update business plan' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/businesses/[businessId]/verification/route.ts
+++ b/src/app/api/admin/businesses/[businessId]/verification/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { setBusinessVerification } from '@server/admin'
+import { HttpError, requireUser, UnauthorizedError } from '@server/auth'
+
+const idSchema = z.string().uuid()
+const bodySchema = z.object({ verified: z.boolean() })
+
+type RouteContext = {
+  params: { businessId: string }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const user = await requireUser()
+
+    if (user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const rateLimit = await checkRateLimit(user.id, 'admin_action')
+
+    if (!rateLimit.allowed) {
+      const retryAfter = Math.max(1, Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000))
+      return NextResponse.json(
+        {
+          error: 'Too many admin actions. Please slow down.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+      )
+    }
+
+    const idResult = idSchema.safeParse(context.params.businessId)
+
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid business id' }, { status: 400 })
+    }
+
+    const payload = bodySchema.safeParse(await request.json())
+
+    if (!payload.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid request body',
+          details: payload.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const status = await setBusinessVerification(idResult.data, payload.data.verified)
+
+    return NextResponse.json({ status, verified: status === 'published' })
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+    }
+
+    console.error('Failed to update business verification', error)
+    return NextResponse.json({ error: 'Failed to update business verification' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/classifieds/[classifiedId]/visibility/route.ts
+++ b/src/app/api/admin/classifieds/[classifiedId]/visibility/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { setClassifiedVisibility } from '@server/admin'
+import { HttpError, requireUser, UnauthorizedError } from '@server/auth'
+
+const idSchema = z.string().uuid()
+const bodySchema = z.object({ hidden: z.boolean() })
+
+type RouteContext = {
+  params: { classifiedId: string }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const user = await requireUser()
+
+    if (user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const rateLimit = await checkRateLimit(user.id, 'admin_action')
+
+    if (!rateLimit.allowed) {
+      const retryAfter = Math.max(1, Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000))
+      return NextResponse.json(
+        {
+          error: 'Too many admin actions. Please slow down.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+      )
+    }
+
+    const idResult = idSchema.safeParse(context.params.classifiedId)
+
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid classified id' }, { status: 400 })
+    }
+
+    const payload = bodySchema.safeParse(await request.json())
+
+    if (!payload.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid request body',
+          details: payload.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const status = await setClassifiedVisibility(idResult.data, payload.data.hidden)
+
+    return NextResponse.json({ status })
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+    }
+
+    console.error('Failed to update classified visibility', error)
+    return NextResponse.json({ error: 'Failed to update classified visibility' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/reports/[reportId]/status/route.ts
+++ b/src/app/api/admin/reports/[reportId]/status/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { updateReportStatus } from '@server/admin'
+import { HttpError, requireUser, UnauthorizedError } from '@server/auth'
+
+const idSchema = z.string().uuid()
+const bodySchema = z.object({
+  status: z.enum(['resolved', 'dismissed']),
+  resolution: z.string().trim().min(1).max(2000).optional(),
+})
+
+type RouteContext = {
+  params: { reportId: string }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const user = await requireUser()
+
+    if (user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const rateLimit = await checkRateLimit(user.id, 'admin_action')
+
+    if (!rateLimit.allowed) {
+      const retryAfter = Math.max(1, Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000))
+      return NextResponse.json(
+        {
+          error: 'Too many admin actions. Please slow down.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+      )
+    }
+
+    const idResult = idSchema.safeParse(context.params.reportId)
+
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid report id' }, { status: 400 })
+    }
+
+    const payload = bodySchema.safeParse(await request.json())
+
+    if (!payload.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid request body',
+          details: payload.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const status = await updateReportStatus(idResult.data, payload.data.status, payload.data.resolution)
+
+    return NextResponse.json({ status })
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+    }
+
+    console.error('Failed to update report status', error)
+    return NextResponse.json({ error: 'Failed to update report status' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/users/[userId]/role/route.ts
+++ b/src/app/api/admin/users/[userId]/role/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { checkRateLimit } from '@/lib/rate-limiting'
+import { updateUserRole } from '@server/admin'
+import { HttpError, requireUser, UnauthorizedError } from '@server/auth'
+import { userRoles } from '@shared/schema'
+
+const idSchema = z.string().uuid()
+const bodySchema = z.object({
+  role: z.enum(userRoles),
+})
+
+type RouteContext = {
+  params: { userId: string }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const user = await requireUser()
+
+    if (user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const rateLimit = await checkRateLimit(user.id, 'admin_action')
+    if (!rateLimit.allowed) {
+      const retryAfter = Math.max(1, Math.ceil((rateLimit.resetTime.getTime() - Date.now()) / 1000))
+      return NextResponse.json(
+        {
+          error: 'Too many admin actions. Please slow down.',
+          retryAfter: rateLimit.resetTime.toISOString(),
+        },
+        { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+      )
+    }
+
+    const idResult = idSchema.safeParse(context.params.userId)
+
+    if (!idResult.success) {
+      return NextResponse.json({ error: 'Invalid user id' }, { status: 400 })
+    }
+
+    const payload = bodySchema.safeParse(await request.json())
+
+    if (!payload.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid request body',
+          details: payload.error.flatten(),
+        },
+        { status: 400 },
+      )
+    }
+
+    await updateUserRole(idResult.data, payload.data.role)
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+    }
+
+    console.error('Failed to update user role', error)
+    return NextResponse.json({ error: 'Failed to update user role' }, { status: 500 })
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { useSession, signOut } from 'next-auth/react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Button } from './ui/Button'
 import { Input } from './ui/Input'
 import { Badge } from './ui/Badge'
@@ -21,7 +21,7 @@ export function Header() {
     }
   }
 
-  const navigation = [
+  const baseNavigation = [
     { name: 'Directory', href: '/directory' },
     { name: 'Providers', href: '/providers' },
     { name: 'Events', href: '/events' },
@@ -30,6 +30,14 @@ export function Header() {
     { name: 'Opportunities', href: '/opportunities' },
     { name: 'Classifieds', href: '/classifieds' },
   ]
+
+  const navigation = useMemo(() => {
+    if (!isAdmin) {
+      return baseNavigation
+    }
+
+    return [...baseNavigation, { name: 'Admin', href: '/admin' }]
+  }, [isAdmin])
 
   return (
     <header className="bg-white shadow-sm border-b">

--- a/src/lib/rate-limiting.ts
+++ b/src/lib/rate-limiting.ts
@@ -44,9 +44,12 @@ export const RATE_LIMIT_CONFIGS = {
   // Contact/communication
   contact_form: { windowMs: 60 * 60 * 1000, maxRequests: 3 }, // 3 contact form submissions per hour
   report_submit: { windowMs: 60 * 60 * 1000, maxRequests: 10 }, // 10 reports per hour
-  
+
   // Search and browsing (more lenient)
   search: { windowMs: 60 * 1000, maxRequests: 50 }, // 50 searches per minute
+
+  // Administrative tools
+  admin_action: { windowMs: 60 * 1000, maxRequests: 40 },
 } as const
 
 // Check rate limit for a specific identifier and endpoint


### PR DESCRIPTION
## Summary
- extend the admin data layer to support user role management, business verification and premium toggles, announcement approvals, classified visibility updates, and report resolution
- introduce admin-only API routes with rate limiting for the new moderation actions
- build an admin dashboard with overview metrics, searchable tables, and action controls, plus expose the entry in the main navigation
- expand the admin API test suite to cover the new PATCH handlers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd3194d4a8832bb4284fbe596585f9