### PR TITLE
Fix Vercel cron schedule syntax

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,7 @@
   "crons": [
     {
       "path": "/api/jobs/digest",
-      "schedule": "0 9 * * MON"
+      "schedule": "0 9 * * 1"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- replace the Vercel cron job schedule to use numeric day-of-week values that Vercel accepts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd401daf20832b9be630f2f1f72d65