### PR TITLE
Add membership checkout polish, rate limit UX, and analytics

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,0 +1,111 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { eq } from 'drizzle-orm'
+
+import { requireUser } from '@server/auth'
+import { db, profiles, users } from '@/lib/db'
+import { BillingPortalButton } from '@/components/billing/BillingPortalButton'
+import { AccessibleButton } from '@/components/ui/AccessibleButton'
+import { buildPageMetadata } from '@/lib/metadata'
+
+const tierDescriptions: Record<string, string> = {
+  FREE: 'Free members can explore community listings and events with limited posting allowances.',
+  PLUS: 'Plus unlocks unlimited classifieds, announcements, and direct messaging with priority support.',
+  FAMILY: 'Family includes everything in Plus and extends premium access to your household.',
+}
+
+const friendlyTier = (tier: string) => {
+  const normalized = tier.toUpperCase()
+  if (normalized === 'PLUS') return 'Plus'
+  if (normalized === 'FAMILY') return 'Family'
+  return 'Free'
+}
+
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Account overview',
+  description: 'Manage your UiQ membership, profile settings, and billing preferences.',
+  path: '/account',
+  category: 'Account',
+})
+
+export default async function AccountPage() {
+  const user = await requireUser()
+
+  const [profile] = await db
+    .select({
+      displayName: profiles.displayName,
+      location: profiles.location,
+    })
+    .from(profiles)
+    .where(eq(profiles.userId, user.id))
+    .limit(1)
+
+  const [account] = await db
+    .select({
+      email: users.email,
+      createdAt: users.createdAt,
+      stripeCustomerId: users.stripeCustomerId,
+    })
+    .from(users)
+    .where(eq(users.id, user.id))
+    .limit(1)
+
+  const membershipTier = user.membershipTier ?? 'FREE'
+  const tierCopy = tierDescriptions[membershipTier] ?? tierDescriptions.FREE
+
+  return (
+    <div className="bg-gray-50 py-12">
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 sm:px-6 lg:px-8">
+        <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Account</p>
+          <h1 className="mt-2 text-3xl font-semibold text-gray-900">
+            {profile?.displayName ?? 'Community member'}
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm text-gray-600">
+            Keep your membership details current so you never miss community updates and premium perks.
+          </p>
+        </section>
+
+        <section className="grid gap-6 md:grid-cols-2">
+          <div className="rounded-2xl border border-primary-100 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-gray-900">Membership tier</h2>
+            <p className="mt-3 inline-flex items-center gap-2 rounded-full bg-primary-50 px-3 py-1 text-sm font-medium text-primary-700">
+              {friendlyTier(membershipTier)}
+            </p>
+            <p className="mt-4 text-sm text-gray-600">{tierCopy}</p>
+            <div className="mt-5 flex flex-wrap gap-3">
+              <Link href="/pricing" className="inline-flex">
+                <AccessibleButton variant="secondary" size="sm">
+                  View membership plans
+                </AccessibleButton>
+              </Link>
+              <BillingPortalButton variant="outline" size="sm" className="inline-flex">
+                Manage subscription
+              </BillingPortalButton>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-gray-900">Account details</h2>
+            <dl className="mt-4 space-y-3 text-sm text-gray-700">
+              <div>
+                <dt className="font-medium text-gray-900">Email</dt>
+                <dd>{account?.email ?? 'Not provided'}</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-gray-900">Member since</dt>
+                <dd>{account?.createdAt ? new Date(account.createdAt).toLocaleDateString() : '—'}</dd>
+              </div>
+              {profile?.location && (
+                <div>
+                  <dt className="font-medium text-gray-900">Location</dt>
+                  <dd>{profile.location}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1,0 +1,134 @@
+import { and, eq, gte, sql } from 'drizzle-orm'
+import { format } from 'date-fns'
+import type { Metadata } from 'next'
+
+import { db, analyticsEvents } from '@/lib/db'
+import { buildPageMetadata } from '@/lib/metadata'
+import { SimpleLineChart } from '@/components/charts/SimpleLineChart'
+
+const WEEKS_TO_PLOT = 8
+
+function startOfCurrentWeek(): Date {
+  const date = new Date()
+  const day = date.getUTCDay()
+  const diff = (day + 6) % 7
+  date.setUTCDate(date.getUTCDate() - diff)
+  date.setUTCHours(0, 0, 0, 0)
+  return date
+}
+
+async function getWeeklyPageViews() {
+  const weekFloor = new Date(startOfCurrentWeek())
+  weekFloor.setUTCDate(weekFloor.getUTCDate() - (WEEKS_TO_PLOT - 1) * 7)
+
+  const rows = await db
+    .select({
+      weekStart: sql<Date>`date_trunc('week', ${analyticsEvents.createdAt})`,
+      count: sql<number>`count(*)`,
+    })
+    .from(analyticsEvents)
+    .where(
+      and(
+        eq(analyticsEvents.kind, 'page_view'),
+        gte(analyticsEvents.createdAt, weekFloor),
+      ),
+    )
+    .groupBy(sql`date_trunc('week', ${analyticsEvents.createdAt})`)
+    .orderBy(sql`date_trunc('week', ${analyticsEvents.createdAt})`)
+
+  const countsByIsoWeek = new Map<string, number>()
+
+  for (const row of rows) {
+    const weekStart = new Date(row.weekStart as unknown as Date)
+    const key = weekStart.toISOString().slice(0, 10)
+    countsByIsoWeek.set(key, Number(row.count))
+  }
+
+  const series: { label: string; value: number }[] = []
+  const today = startOfCurrentWeek()
+
+  for (let index = WEEKS_TO_PLOT - 1; index >= 0; index -= 1) {
+    const weekDate = new Date(today)
+    weekDate.setUTCDate(today.getUTCDate() - index * 7)
+    const key = weekDate.toISOString().slice(0, 10)
+    const value = countsByIsoWeek.get(key) ?? 0
+    series.push({ label: format(weekDate, 'MMM d'), value })
+  }
+
+  return series
+}
+
+export default async function AdminAnalyticsPage() {
+  const weeklySeries = await getWeeklyPageViews()
+  const totalViews = weeklySeries.reduce((sum, point) => sum + point.value, 0)
+  const latestWeek = weeklySeries.at(-1)?.value ?? 0
+  const previousWeek = weeklySeries.at(-2)?.value ?? 0
+  const delta = latestWeek - previousWeek
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h2 className="text-xl font-semibold text-gray-900">Engagement analytics</h2>
+        <p className="text-sm text-gray-600">
+          Lightweight tracking of page views across the platform. Use this to spot engagement trends and plan campaigns.
+        </p>
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">Views (last 7 days)</p>
+          <p className="mt-2 text-3xl font-semibold text-gray-900">{latestWeek}</p>
+          <p className="mt-1 text-xs text-gray-500">
+            {delta === 0
+              ? 'No change from previous week'
+              : delta > 0
+              ? `Up ${delta} week over week`
+              : `Down ${Math.abs(delta)} vs previous week`}
+          </p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">Total views (last {WEEKS_TO_PLOT} weeks)</p>
+          <p className="mt-2 text-3xl font-semibold text-gray-900">{totalViews}</p>
+          <p className="mt-1 text-xs text-gray-500">Aggregated from lightweight page view events.</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">Average per week</p>
+          <p className="mt-2 text-3xl font-semibold text-gray-900">
+            {Math.round(totalViews / (weeklySeries.length || 1))}
+          </p>
+          <p className="mt-1 text-xs text-gray-500">Baseline to gauge marketing pushes.</p>
+        </div>
+      </section>
+
+      <SimpleLineChart data={weeklySeries} />
+
+      <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+            <tr>
+              <th scope="col" className="px-4 py-3 text-left">Week starting</th>
+              <th scope="col" className="px-4 py-3 text-left">Page views</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {weeklySeries.map((point) => (
+              <tr key={point.label}>
+                <td className="px-4 py-3 text-gray-700">{point.label}</td>
+                <td className="px-4 py-3 font-medium text-gray-900">{point.value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  )
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return buildPageMetadata({
+    title: 'Analytics overview',
+    description: 'Track weekly UiQ page views and identify engagement trends.',
+    path: '/admin/analytics',
+    category: 'Administration',
+  })
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,6 +6,7 @@ import { requireUser, UnauthorizedError } from '@server/auth'
 
 export const adminNavItems = [
   { name: 'Overview', href: '/admin' },
+  { name: 'Analytics', href: '/admin/analytics' },
   { name: 'Users', href: '/admin/users' },
   { name: 'Businesses', href: '/admin/businesses' },
   { name: 'Announcements', href: '/admin/announcements' },

--- a/src/app/api/analytics/page-view/route.ts
+++ b/src/app/api/analytics/page-view/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { db, analyticsEvents } from '@/lib/db'
+import { getSessionUser } from '../../../../../server/auth'
+
+const payloadSchema = z.object({
+  path: z.string().min(1).max(512),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionUser = await getSessionUser()
+    const json = await request.json().catch(() => ({}))
+    const parsed = payloadSchema.safeParse(json)
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+    }
+
+    await db.insert(analyticsEvents).values({
+      kind: 'page_view',
+      path: parsed.data.path.slice(0, 512),
+      userId: sessionUser?.id ?? null,
+      metadata: sessionUser ? { userEmail: sessionUser.email } : {},
+    })
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('Failed to record page view', error)
+    return NextResponse.json({ error: 'Unable to record page view' }, { status: 500 })
+  }
+}

--- a/src/app/api/stripe/checkout/confirm/route.ts
+++ b/src/app/api/stripe/checkout/confirm/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import type Stripe from 'stripe'
+import { eq } from 'drizzle-orm'
+
+import { stripe } from '@/lib/stripe'
+import { db, subscriptions, users, type MembershipTier } from '@/lib/db'
+import { requireUser } from '../../../../../../server/auth'
+
+const payloadSchema = z.object({
+  sessionId: z.string().min(1),
+})
+
+const VALID_TIERS: MembershipTier[] = ['FREE', 'PLUS', 'FAMILY']
+
+function resolveTier(subscription: Stripe.Subscription, session: Stripe.Checkout.Session): MembershipTier {
+  const potential =
+    session.metadata?.membershipTier ??
+    subscription.metadata?.membershipTier ??
+    subscription.metadata?.tier ??
+    subscription.items.data[0]?.price?.metadata?.tier ??
+    (typeof subscription.items.data[0]?.price?.product === 'object'
+      ? (subscription.items.data[0]?.price?.product.metadata?.tier as string | undefined)
+      : undefined)
+
+  const normalised = typeof potential === 'string' ? potential.trim().toUpperCase() : 'FREE'
+  return (VALID_TIERS.includes(normalised as MembershipTier) ? normalised : 'FREE') as MembershipTier
+}
+
+function resolveStatus(status: Stripe.Subscription.Status | undefined) {
+  switch (status) {
+    case 'active':
+    case 'trialing':
+    case 'past_due':
+    case 'canceled':
+    case 'incomplete':
+      return status
+    default:
+      return 'active'
+  }
+}
+
+function toDate(value: number | null | undefined) {
+  return typeof value === 'number' ? new Date(value * 1000) : null
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireUser()
+    const payload = await request.json().catch(() => ({}))
+    const parsed = payloadSchema.safeParse(payload)
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+    }
+
+    const session = await stripe.checkout.sessions.retrieve(parsed.data.sessionId, {
+      expand: ['subscription', 'subscription.items.data.price.product', 'customer'],
+    })
+
+    if (!session.subscription) {
+      return NextResponse.json({ error: 'No subscription associated with session' }, { status: 400 })
+    }
+
+    const subscription =
+      typeof session.subscription === 'string'
+        ? await stripe.subscriptions.retrieve(session.subscription, {
+            expand: ['items.data.price.product'],
+          })
+        : session.subscription
+
+    const customerId =
+      typeof session.customer === 'string'
+        ? session.customer
+        : session.customer?.id ?? (typeof subscription.customer === 'string' ? subscription.customer : null)
+
+    if (!customerId) {
+      return NextResponse.json({ error: 'Missing Stripe customer' }, { status: 400 })
+    }
+
+    const membershipTier = resolveTier(subscription, session)
+    const status = resolveStatus(subscription.status)
+    const periodStart = toDate(subscription.current_period_start) ?? new Date()
+    const periodEnd = toDate(subscription.current_period_end) ?? periodStart
+    const trialEndsAt = toDate(subscription.trial_end)
+    const cancelAt = toDate(subscription.cancel_at)
+    const canceledAt = toDate(subscription.canceled_at)
+
+    await db
+      .update(users)
+      .set({ stripeCustomerId: customerId, updatedAt: new Date() })
+      .where(eq(users.id, user.id))
+
+    const [existing] = await db
+      .select({ id: subscriptions.id })
+      .from(subscriptions)
+      .where(eq(subscriptions.providerSubscriptionId, subscription.id))
+      .limit(1)
+
+    const metadata = {
+      ...(subscription.metadata ?? {}),
+      ...(session.metadata ?? {}),
+    }
+
+    if (existing) {
+      await db
+        .update(subscriptions)
+        .set({
+          currentTier: membershipTier,
+          status,
+          providerCustomerId: customerId,
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+          cancelAt,
+          canceledAt,
+          trialEndsAt,
+          metadata,
+          updatedAt: new Date(),
+        })
+        .where(eq(subscriptions.id, existing.id))
+    } else {
+      await db.insert(subscriptions).values({
+        userId: user.id,
+        businessId: null,
+        currentTier: membershipTier,
+        status,
+        provider: 'stripe',
+        providerCustomerId: customerId,
+        providerSubscriptionId: subscription.id,
+        trialEndsAt,
+        currentPeriodStart: periodStart,
+        currentPeriodEnd: periodEnd,
+        cancelAt,
+        canceledAt,
+        metadata,
+      })
+    }
+
+    return NextResponse.json({ ok: true, customerId, tier: membershipTier })
+  } catch (error) {
+    console.error('Failed to confirm checkout session', error)
+    return NextResponse.json({ error: 'Failed to confirm checkout' }, { status: 500 })
+  }
+}

--- a/src/app/billing/success/page.tsx
+++ b/src/app/billing/success/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { AccessibleButton } from '@/components/ui/AccessibleButton'
+import { BillingPortalButton } from '@/components/billing/BillingPortalButton'
 import Link from 'next/link'
 
 export default function BillingSuccessPage() {
@@ -26,9 +27,61 @@ function BillingSuccessContent() {
   const searchParams = useSearchParams()
   const sessionId = searchParams.get('session_id')
   const [loading, setLoading] = useState(true)
+  const [syncState, setSyncState] = useState<'idle' | 'processing' | 'success' | 'error'>('idle')
+  const [syncError, setSyncError] = useState<string | null>(null)
 
   useEffect(() => {
-    setLoading(false)
+    let cancelled = false
+
+    async function confirmSubscription() {
+      if (!sessionId) {
+        setLoading(false)
+        return
+      }
+
+      setSyncState('processing')
+      setSyncError(null)
+
+      try {
+        const response = await fetch('/api/stripe/checkout/confirm', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId }),
+        })
+
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}))
+          const message =
+            payload && typeof payload === 'object' && 'error' in payload
+              ? String(payload.error)
+              : 'We could not finalise your subscription. The Stripe webhook will retry shortly.'
+          throw new Error(message)
+        }
+
+        if (!cancelled) {
+          setSyncState('success')
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setSyncState('error')
+          setSyncError(
+            error instanceof Error
+              ? error.message
+              : 'Unable to confirm your subscription yet. Please refresh in a moment.',
+          )
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void confirmSubscription()
+
+    return () => {
+      cancelled = true
+    }
   }, [sessionId])
 
   if (loading) {
@@ -45,34 +98,37 @@ function BillingSuccessContent() {
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center">
       <div className="max-w-md w-full bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center">
-        {/* Success Icon */}
+        {syncState === 'processing' && (
+          <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700">
+            Activating your membership. This usually takes just a moment.
+          </div>
+        )}
+
+        {syncState === 'success' && (
+          <div className="mb-6 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            Your subscription is active. A confirmation email is on the way.
+          </div>
+        )}
+
+        {syncState === 'error' && syncError && (
+          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {syncError}
+          </div>
+        )}
+
         <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
-          <svg
-            className="w-8 h-8 text-green-600"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M5 13l4 4L19 7"
-            />
+          <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
           </svg>
         </div>
 
-        {/* Success Message */}
-        <h1 className="text-2xl font-bold text-gray-900 mb-4">
-          Payment Successful!
-        </h1>
-        
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">Payment Successful!</h1>
+
         <p className="text-gray-600 mb-8">
-          Thank you for your subscription to the UiQ Community Platform. 
-          Your payment has been processed successfully and your account has been upgraded.
+          Thank you for your subscription to the UiQ Community Platform. Your payment has been processed successfully and your
+          account has been upgraded.
         </p>
 
-        {/* Session ID */}
         {sessionId && (
           <div className="bg-gray-50 rounded-lg p-4 mb-6">
             <p className="text-xs text-gray-500 mb-1">Transaction ID</p>
@@ -80,7 +136,6 @@ function BillingSuccessContent() {
           </div>
         )}
 
-        {/* Next Steps */}
         <div className="space-y-4">
           <div className="text-left">
             <h3 className="text-sm font-medium text-gray-900 mb-3">What&apos;s next?</h3>
@@ -106,23 +161,25 @@ function BillingSuccessContent() {
             </ul>
           </div>
 
-          {/* Action Buttons */}
           <div className="space-y-3 pt-4">
             <Link href="/dashboard" className="block">
               <AccessibleButton variant="primary" className="w-full">
                 Go to Dashboard
               </AccessibleButton>
             </Link>
-            
+
             <Link href="/billing" className="block">
               <AccessibleButton variant="outline" className="w-full">
                 Manage Billing
               </AccessibleButton>
             </Link>
+
+            <BillingPortalButton variant="outline" size="sm" className="w-full">
+              Open customer portal
+            </BillingPortalButton>
           </div>
         </div>
 
-        {/* Support */}
         <div className="mt-8 pt-6 border-t border-gray-200">
           <p className="text-xs text-gray-500">
             Need help? <a href="/contact" className="text-blue-600 hover:underline">Contact our support team</a>

--- a/src/app/pricing/PricingContent.tsx
+++ b/src/app/pricing/PricingContent.tsx
@@ -1,14 +1,19 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import { useSession } from 'next-auth/react'
 import { PricingTable } from '@/components/billing/PricingTable'
+import { CheckoutButton } from '@/components/billing/CheckoutButton'
+import { BillingPortalButton } from '@/components/billing/BillingPortalButton'
 import { useToast } from '@/hooks/use-toast'
 
 export function PricingContent() {
   const [loading, setLoading] = useState(false)
+  const [membershipPrices, setMembershipPrices] = useState<Record<string, { monthly?: string; yearly?: string; name: string }>>({})
+  const { data: session } = useSession()
   const { toast } = useToast()
 
-  const handleSelectPlan = async (priceId: string, productName: string) => {
+  const handleSelectPlan = async (priceId: string, productName: string, tier?: string) => {
     try {
       setLoading(true)
 
@@ -20,7 +25,8 @@ export function PricingContent() {
         body: JSON.stringify({
           priceId,
           metadata: {
-            productName
+            productName,
+            ...(tier ? { membershipTier: tier.toUpperCase() } : {})
           }
         })
       })
@@ -49,6 +55,28 @@ export function PricingContent() {
     }
   }
 
+  const handlePricesLoaded = (products: Array<{ tier: string; name: string; prices: Array<{ interval: string | null; stripePriceId: string }> }>) => {
+    const next: Record<string, { monthly?: string; yearly?: string; name: string }> = {}
+
+    for (const product of products) {
+      if (product.prices.length === 0) continue
+      const monthly = product.prices.find((price) => price.interval === 'month')
+      const yearly = product.prices.find((price) => price.interval === 'year')
+      next[product.tier] = {
+        monthly: monthly?.stripePriceId,
+        yearly: yearly?.stripePriceId,
+        name: product.name,
+      }
+    }
+
+    setMembershipPrices(next)
+  }
+
+  const membershipTierValue = (session?.user as { membershipTier?: string } | undefined)?.membershipTier
+  const currentTier = useMemo(() => membershipTierValue?.toLowerCase(), [membershipTierValue])
+  const plusPriceId = membershipPrices['plus']?.monthly ?? null
+  const familyPriceId = membershipPrices['family']?.monthly ?? null
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="bg-white border-b border-gray-200">
@@ -60,12 +88,43 @@ export function PricingContent() {
             <p className="text-lg text-gray-600 max-w-2xl mx-auto">
               Support the UiQ community, unlock premium exposure for your business, and access member-only events.
             </p>
+            <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+              <CheckoutButton
+                priceId={plusPriceId ?? ''}
+                productName={membershipPrices['plus']?.name ?? 'Member_Plus'}
+                metadata={{ membershipTier: 'PLUS' }}
+                disabled={!plusPriceId || loading}
+                className="min-w-[220px]"
+              >
+                Upgrade to Plus
+              </CheckoutButton>
+              <CheckoutButton
+                priceId={familyPriceId ?? ''}
+                productName={membershipPrices['family']?.name ?? 'Member_Family'}
+                metadata={{ membershipTier: 'FAMILY' }}
+                variant="secondary"
+                disabled={!familyPriceId || loading}
+                className="min-w-[220px]"
+              >
+                Upgrade to Family
+              </CheckoutButton>
+              {session && (
+                <BillingPortalButton variant="outline" size="sm" className="min-w-[220px]">
+                  Manage subscription
+                </BillingPortalButton>
+              )}
+            </div>
           </div>
         </div>
       </div>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <PricingTable loading={loading} onSelectPlan={handleSelectPlan} />
+        <PricingTable
+          loading={loading}
+          onSelectPlan={handleSelectPlan}
+          currentTier={currentTier}
+          onPricesLoaded={handlePricesLoaded}
+        />
       </div>
     </div>
   )

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { SessionProvider } from 'next-auth/react'
 import { ReactNode, useState } from 'react'
 
+import { RateLimitProvider } from '@/components/notifications/RateLimitProvider'
+import { PageViewTracker } from '@/components/analytics/PageViewTracker'
+
 interface ProvidersProps {
   children: ReactNode
 }
@@ -29,7 +32,10 @@ export function Providers({ children }: ProvidersProps) {
   return (
     <SessionProvider>
       <QueryClientProvider client={queryClient}>
-        {children}
+        <RateLimitProvider>
+          <PageViewTracker />
+          {children}
+        </RateLimitProvider>
       </QueryClientProvider>
     </SessionProvider>
   )

--- a/src/components/analytics/PageViewTracker.tsx
+++ b/src/components/analytics/PageViewTracker.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
+
+const ENDPOINT = '/api/analytics/page-view'
+
+export function PageViewTracker() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const previousPath = useRef<string>('')
+
+  useEffect(() => {
+    if (!pathname) {
+      return
+    }
+
+    const query = searchParams?.toString()
+    const fullPath = query ? `${pathname}?${query}` : pathname
+
+    if (previousPath.current === fullPath) {
+      return
+    }
+
+    previousPath.current = fullPath
+
+    const payload = JSON.stringify({ path: fullPath })
+
+    if (navigator.sendBeacon) {
+      const blob = new Blob([payload], { type: 'application/json' })
+      navigator.sendBeacon(ENDPOINT, blob)
+      return
+    }
+
+    void fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload,
+      keepalive: true,
+    }).catch((error) => {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('Failed to record page view', error)
+      }
+    })
+  }, [pathname, searchParams])
+
+  return null
+}

--- a/src/components/billing/BillingPortalButton.tsx
+++ b/src/components/billing/BillingPortalButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { AccessibleButton } from '@/components/ui/AccessibleButton'
+import { AccessibleButton, type AccessibleButtonProps } from '@/components/ui/AccessibleButton'
 import { useToast } from '@/hooks/use-toast'
 
 interface BillingPortalButtonProps {
@@ -9,13 +9,15 @@ interface BillingPortalButtonProps {
   className?: string
   children?: React.ReactNode
   variant?: 'primary' | 'secondary' | 'outline'
+  size?: AccessibleButtonProps['size']
 }
 
 export function BillingPortalButton({
   businessId,
   className,
   children,
-  variant = 'outline'
+  variant = 'outline',
+  size = 'md'
 }: BillingPortalButtonProps) {
   const [loading, setLoading] = useState(false)
   const { toast } = useToast()
@@ -74,6 +76,7 @@ export function BillingPortalButton({
       onClick={handleOpenPortal}
       disabled={loading}
       variant={variant}
+      size={size}
       className={className}
     >
       {loading ? 'Opening...' : children || 'Manage Billing'}

--- a/src/components/billing/CheckoutButton.tsx
+++ b/src/components/billing/CheckoutButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { AccessibleButton } from '@/components/ui/AccessibleButton'
+import { AccessibleButton, type AccessibleButtonProps } from '@/components/ui/AccessibleButton'
 import { useToast } from '@/hooks/use-toast'
 
 interface CheckoutButtonProps {
@@ -13,6 +13,9 @@ interface CheckoutButtonProps {
   className?: string
   children?: React.ReactNode
   metadata?: Record<string, string>
+  variant?: AccessibleButtonProps['variant']
+  size?: AccessibleButtonProps['size']
+  disabled?: boolean
 }
 
 export function CheckoutButton({
@@ -23,7 +26,10 @@ export function CheckoutButton({
   trialPeriodDays,
   className,
   children,
-  metadata = {}
+  metadata = {},
+  variant = 'primary',
+  size = 'md',
+  disabled,
 }: CheckoutButtonProps) {
   const [loading, setLoading] = useState(false)
   const { toast } = useToast()
@@ -78,7 +84,9 @@ export function CheckoutButton({
   return (
     <AccessibleButton
       onClick={handleCheckout}
-      disabled={loading}
+      disabled={loading || disabled}
+      variant={variant}
+      size={size}
       className={className}
     >
       {loading ? 'Starting checkout...' : children || `Subscribe to ${productName}`}

--- a/src/components/billing/PricingTable.tsx
+++ b/src/components/billing/PricingTable.tsx
@@ -26,12 +26,13 @@ interface Product {
 
 interface PricingTableProps {
   type: 'membership' | 'business'
-  onSelectPlan: (priceId: string, productName: string) => void
+  onSelectPlan: (priceId: string, productName: string, tier?: string) => void
   currentTier?: string
   loading?: boolean
+  onPricesLoaded?: (products: Product[]) => void
 }
 
-export function PricingTable({ type, onSelectPlan, currentTier, loading }: PricingTableProps) {
+export function PricingTable({ type, onSelectPlan, currentTier, loading, onPricesLoaded }: PricingTableProps) {
   const [products, setProducts] = useState<Product[]>([])
   const [billingInterval, setBillingInterval] = useState<'month' | 'year'>('month')
   const [loadingProducts, setLoadingProducts] = useState(true)
@@ -41,7 +42,9 @@ export function PricingTable({ type, onSelectPlan, currentTier, loading }: Prici
       setLoadingProducts(true)
       const response = await fetch(`/api/stripe/products?type=${type}`)
       const data = await response.json()
-      setProducts(data.products || [])
+      const fetchedProducts: Product[] = data.products || []
+      setProducts(fetchedProducts)
+      onPricesLoaded?.(fetchedProducts)
     } catch (error) {
       console.error('Error fetching products:', error)
     } finally {
@@ -203,7 +206,7 @@ export function PricingTable({ type, onSelectPlan, currentTier, loading }: Prici
                 </div>
 
                 <AccessibleButton
-                  onClick={() => price && onSelectPlan(price.stripePriceId, product.name)}
+                  onClick={() => price && onSelectPlan(price.stripePriceId, product.name, product.tier)}
                   variant={getButtonVariant(product.tier)}
                   disabled={loading || isCurrentPlan(product.tier) || product.tier === 'free'}
                   className="w-full mb-6"

--- a/src/components/charts/SimpleLineChart.tsx
+++ b/src/components/charts/SimpleLineChart.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { memo } from 'react'
+import { cn } from '@/lib/utils'
+
+type DataPoint = {
+  label: string
+  value: number
+}
+
+export interface SimpleLineChartProps {
+  data: DataPoint[]
+  className?: string
+}
+
+function buildPolylinePoints(data: DataPoint[]) {
+  if (data.length === 0) {
+    return ''
+  }
+
+  const maxValue = Math.max(...data.map((point) => point.value), 1)
+  const width = data.length === 1 ? 1 : data.length - 1
+
+  return data
+    .map((point, index) => {
+      const x = (index / width) * 100
+      const scaled = maxValue === 0 ? 0 : point.value / maxValue
+      const y = 100 - scaled * 100
+      return `${x.toFixed(2)},${y.toFixed(2)}`
+    })
+    .join(' ')
+}
+
+function SimpleLineChartComponent({ data, className }: SimpleLineChartProps) {
+  const points = buildPolylinePoints(data)
+  const maxValue = Math.max(...data.map((point) => point.value), 1)
+
+  return (
+    <div className={cn('w-full rounded-xl border border-gray-200 bg-white p-4 shadow-sm', className)}>
+      <div className="flex items-baseline justify-between">
+        <p className="text-sm font-semibold text-gray-900">Weekly page views</p>
+        <span className="text-xs text-gray-500">Last {data.length} weeks</span>
+      </div>
+      <div className="mt-4">
+        <svg
+          viewBox={`0 0 100 100`}
+          preserveAspectRatio="none"
+          className="h-40 w-full text-primary-600"
+          role="img"
+          aria-hidden={false}
+        >
+          <polyline
+            points={points}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2.4}
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+      </div>
+      <div className="mt-3 grid grid-cols-4 gap-2 text-xs text-gray-600">
+        {data.map((point) => (
+          <div key={point.label} className="min-w-0">
+            <p className="truncate font-medium text-gray-800">{point.value}</p>
+            <p className="truncate text-gray-500">{point.label}</p>
+          </div>
+        ))}
+      </div>
+      <p className="mt-3 text-xs text-gray-500">Peak: {maxValue} views/week</p>
+    </div>
+  )
+}
+
+export const SimpleLineChart = memo(SimpleLineChartComponent)

--- a/src/components/forms/ClassifiedSubmissionForm.tsx
+++ b/src/components/forms/ClassifiedSubmissionForm.tsx
@@ -8,6 +8,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { uploadImageViaApi } from '@/lib/uploads'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
+import { useRateLimitNotice } from '@/components/notifications/RateLimitProvider'
 
 const classifiedFormSchema = z.object({
   title: z.string().trim().min(3, 'Title must be at least 3 characters').max(255),
@@ -92,6 +93,7 @@ export function ClassifiedSubmissionForm() {
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [uploadedImages, setUploadedImages] = useState<UploadedImage[]>([])
   const [isUploading, setIsUploading] = useState(false)
+  const { showNotice } = useRateLimitNotice()
 
   const {
     register,
@@ -235,6 +237,14 @@ export function ClassifiedSubmissionForm() {
         data = text.length > 0 ? JSON.parse(text) : null
       } catch {
         data = null
+      }
+
+      if (response.status === 429) {
+        showNotice('classifieds')
+        setSubmitError(
+          'Free members can publish two classifieds each month. Upgrade to Plus for unlimited listings and faster approvals.',
+        )
+        return
       }
 
       if (!response.ok) {

--- a/src/components/notifications/RateLimitBanner.tsx
+++ b/src/components/notifications/RateLimitBanner.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import Link from 'next/link'
+import { AccessibleButton } from '@/components/ui/AccessibleButton'
+import { cn } from '@/lib/utils'
+
+export type RateLimitFeature = 'classifieds' | 'announcements' | 'messages'
+
+const FEATURE_COPY: Record<RateLimitFeature, {
+  heading: string
+  description: string
+  highlight: string
+}> = {
+  classifieds: {
+    heading: "You've reached the classifieds limit",
+    description:
+      'Free members can publish up to two classifieds each month. Upgrade to Plus to unlock unlimited listings and faster approvals.',
+    highlight: 'Plus members enjoy unlimited classifieds and priority placement.',
+  },
+  announcements: {
+    heading: "You're at the announcement limit",
+    description:
+      'Free members can share one community announcement per month. Upgrading unlocks unlimited notices and priority moderator review.',
+    highlight: 'Plus and Family plans include unlimited announcements.',
+  },
+  messages: {
+    heading: "Daily messaging limit reached",
+    description:
+      'Free members can send up to 200 direct messages per day. Upgrade to keep conversations going without interruption.',
+    highlight: 'Premium plans remove the daily messaging cap.',
+  },
+}
+
+export interface RateLimitBannerProps {
+  feature: RateLimitFeature
+  onDismiss?: () => void
+  className?: string
+}
+
+export function RateLimitBanner({ feature, onDismiss, className }: RateLimitBannerProps) {
+  const copy = FEATURE_COPY[feature]
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        'pointer-events-auto w-full max-w-xl rounded-xl border border-amber-200 bg-amber-50/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:backdrop-blur-md',
+        className,
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-1 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700">
+          <svg
+            className="h-5 w-5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 9v4m0 4h.01" />
+            <path d="M21 18v-6a9 9 0 10-18 0v6" />
+            <path d="M5 21h14" />
+          </svg>
+        </div>
+        <div className="flex-1 space-y-2">
+          <div>
+            <p className="text-sm font-semibold text-amber-900">{copy.heading}</p>
+            <p className="mt-1 text-sm text-amber-800">{copy.description}</p>
+            <p className="mt-2 text-sm font-medium text-amber-900">{copy.highlight}</p>
+          </div>
+          <div className="flex flex-wrap gap-3 pt-1">
+            <AccessibleButton
+              size="sm"
+              variant="primary"
+              onClick={() => {
+                window.scrollTo({ top: 0, behavior: 'smooth' })
+              }}
+            >
+              Explore upgrades
+            </AccessibleButton>
+            <Link
+              href="/pricing"
+              className="inline-flex items-center text-sm font-semibold text-amber-900 underline-offset-4 hover:underline"
+            >
+              View membership plans
+            </Link>
+          </div>
+        </div>
+        <AccessibleButton
+          variant="text"
+          size="sm"
+          aria-label="Dismiss rate limit notice"
+          onClick={onDismiss}
+          className="-mr-1 mt-1 text-amber-700 hover:text-amber-900"
+        >
+          <span aria-hidden="true">×</span>
+        </AccessibleButton>
+      </div>
+    </div>
+  )
+}

--- a/src/components/notifications/RateLimitProvider.tsx
+++ b/src/components/notifications/RateLimitProvider.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import { RateLimitBanner, type RateLimitFeature } from './RateLimitBanner'
+
+type RateLimitNotice = {
+  feature: RateLimitFeature
+  id: number
+}
+
+type RateLimitContextValue = {
+  showNotice: (feature: RateLimitFeature) => void
+  dismiss: () => void
+}
+
+const RateLimitContext = createContext<RateLimitContextValue | null>(null)
+
+export function RateLimitProvider({ children }: { children: React.ReactNode }) {
+  const [notice, setNotice] = useState<RateLimitNotice | null>(null)
+
+  const showNotice = useCallback((feature: RateLimitFeature) => {
+    setNotice({ feature, id: Date.now() })
+  }, [])
+
+  const dismiss = useCallback(() => {
+    setNotice(null)
+  }, [])
+
+  const value = useMemo(() => ({ showNotice, dismiss }), [showNotice, dismiss])
+
+  return (
+    <RateLimitContext.Provider value={value}>
+      {notice && (
+        <div className="pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-center px-4 sm:px-6">
+          <RateLimitBanner
+            key={notice.id}
+            feature={notice.feature}
+            onDismiss={dismiss}
+            className="pointer-events-auto"
+          />
+        </div>
+      )}
+      {children}
+    </RateLimitContext.Provider>
+  )
+}
+
+export function useRateLimitNotice() {
+  const context = useContext(RateLimitContext)
+
+  if (!context) {
+    throw new Error('useRateLimitNotice must be used within a RateLimitProvider')
+  }
+
+  return context
+}


### PR DESCRIPTION
## Summary
- add Stripe customer persistence, checkout confirmation, and quick upgrade/portal actions across pricing and success views
- introduce reusable rate-limit banner/provider and display classifieds 429 guidance
- log page-view analytics events and surface an admin weekly chart overview

## Testing
- npm run lint
- npm run type-check *(fails: existing schema/type mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68cd50e704e0832b9baa67ff26b165d6