### PR TITLE
Add client directive to AccessibleButton

### DIFF
--- a/src/components/ui/AccessibleButton.tsx
+++ b/src/components/ui/AccessibleButton.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { ButtonHTMLAttributes, forwardRef, useRef } from 'react'
 import { cn } from '@/lib/utils'
 import { LiveRegion } from '@/lib/accessibility'


### PR DESCRIPTION
## Summary
- mark the AccessibleButton component as a client component so hooks like `useRef` can be used during Next.js builds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd59c75908832b8d432d16a6b23fa9